### PR TITLE
feat: save channelName in YouTube video search flow

### DIFF
--- a/src/infrastructure/database/MongoRepository.ts
+++ b/src/infrastructure/database/MongoRepository.ts
@@ -49,6 +49,7 @@ export interface YoutubeVideo {
   thumb: string
   title: string
   url: string
+  channelName: string
 }
 
 export interface YoutubeVideoDoc {
@@ -57,6 +58,7 @@ export interface YoutubeVideoDoc {
   title: string
   link: string
   savedAt: Date
+  channelName: string
   watchLater?: boolean
 }
 
@@ -65,7 +67,7 @@ export async function saveYoutubeVideos(videos: YoutubeVideo[]): Promise<void> {
   const col = MongoConnection.getCollection<YoutubeVideoDoc>(YOUTUBE_RSS_COLLECTION)
   const savedAt = new Date()
   await col.insertMany(
-    videos.map(v => ({ videoId: v.videoId, thumb: v.thumb, title: v.title, link: v.url, savedAt }))
+    videos.map(v => ({ videoId: v.videoId, thumb: v.thumb, title: v.title, link: v.url, channelName: v.channelName, savedAt }))
   )
 }
 

--- a/src/services/youtube/YoutubeRssService.ts
+++ b/src/services/youtube/YoutubeRssService.ts
@@ -18,6 +18,7 @@ export interface YoutubeVideo {
   thumb: string
   published: Date
   channelId: string
+  channelName: string
 }
 
 // ── Auth helpers ──────────────────────────────────────────────────────────
@@ -65,6 +66,7 @@ function mapActivityToVideo(item: Record<string, unknown>, channelId: string): Y
     thumb: `${YOUTUBE_THUMB_URL}/${videoId}/mqdefault.jpg`,
     published,
     channelId: channelId || (sn.channelId as string) || '',
+    channelName: (sn.channelTitle as string) || '',
   }
 }
 


### PR DESCRIPTION
Add channelName field to YoutubeVideo and YoutubeVideoDoc interfaces.
Extract channelTitle from YouTube API snippet and persist it to MongoDB.

https://claude.ai/code/session_01Ky1NZkN7nwaM7K1d9knJT6