### PR TITLE
refactor: padronizar todos os logs com pino via createLogger

### DIFF
--- a/src/adapters/google-Oauth.ts
+++ b/src/adapters/google-Oauth.ts
@@ -1,6 +1,9 @@
 import { google } from 'googleapis'
 import { env } from '../config/env'
 import { getGoogleOAuthToken, saveGoogleOAuthToken } from '../infrastructure/database/MongoRepository'
+import { createLogger } from '../shared/logger/Logger'
+
+const log = createLogger('GoogleOAuth')
 
 const oAuth2Client = new google.auth.OAuth2(
   env.GOOGLE_CLIENT_ID,
@@ -49,7 +52,7 @@ function setAuthToken(tokenOrUrl: unknown): Promise<typeof oAuth2Client> {
         saveGoogleOAuthToken(token)
           .then(() => {
             googleOAuthState.authorized = true
-            console.log('Token Google salvo no banco (expira em 7 dias)')
+            log.info('Token Google salvo no banco (expira em 7 dias)')
             resolve(oAuth2Client)
           })
           .catch(reject)
@@ -73,7 +76,7 @@ async function loadTokenFromDb(): Promise<void> {
     oAuth2Client.setCredentials(token as any)
     googleOAuthState.authorized = true
     googleOAuthState.authUrl = null
-    console.log('Token Google carregado do banco')
+    log.info('Token Google carregado do banco')
   } else {
     googleOAuthState.authorized = false
     googleOAuthState.authUrl = getAuthUrl()

--- a/src/audio/listening-audio-stream.ts
+++ b/src/audio/listening-audio-stream.ts
@@ -2,8 +2,11 @@ import { pipeline } from 'node:stream'
 import { createWriteStream } from 'node:fs'
 import { EndBehaviorType, VoiceReceiver } from '@discordjs/voice'
 import path from 'path'
+import { createLogger } from '../shared/logger/Logger'
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const prism = require('prism-media')
+
+const log = createLogger('ListeningStream')
 
 interface DiscordUser {
   username: string
@@ -40,11 +43,11 @@ export function ListeningStream(
   const filename = path.resolve(__dirname, `audio-${Date.now()}-${getDisplayName(userId, user)}.ogg`)
   const out = createWriteStream(filename)
 
-  console.log(`👂 Started recording ${filename}`)
+  log.info({ filename }, 'Started recording')
 
   pipeline(opusStream, oggStream, out, (err) => {
     if (err) {
-      console.warn(`❌ Error recording file ${filename} - ${err.message}`)
+      log.warn({ err, filename }, 'Error recording file')
     } else {
       callback(filename)
     }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -12,6 +12,9 @@ import conversationHistoryGpt from './services/ConversationHistoryGpt'
 import { googleOAuthState } from './adapters/google-Oauth'
 import { init as initWhatsApp } from './services/WhatsAppService'
 import { MongoConnection } from './infrastructure/database/MongoConnection'
+import { createLogger } from './shared/logger/Logger'
+
+const log = createLogger('bot')
 
 const client = new Client({
   partials: ['CHANNEL'],
@@ -27,7 +30,7 @@ const client = new Client({
 client.login(env.BOT_TOKEN)
 
 const prefix: string = process.env.NODE_ENV === 'dev' ? '!' : '$'
-console.log('Comando do bot ', prefix)
+log.info({ prefix }, 'Comando do bot')
 
 function avisarQueEstaOnline(): void {
   if (process.env.NODE_ENV === 'dev') return
@@ -35,7 +38,7 @@ function avisarQueEstaOnline(): void {
   if (channel?.send) {
     listarAsUltimasFeatures(channel)
   } else {
-    console.log('nao consegui enviar mensagem ::', channel)
+    log.warn({ channel }, 'nao consegui enviar mensagem')
   }
 }
 
@@ -43,7 +46,7 @@ client.on('ready', async () => {
   try {
     await MongoConnection.connect(env.MONGO_URL)
     await googleOAuthState.loadTokenFromDb()
-    initWhatsApp().catch((e: Error) => console.error('WhatsApp init', e))
+    initWhatsApp().catch((e: Error) => log.error({ err: e }, 'WhatsApp init error'))
     avisarQueEstaOnline()
 
     const context = createContext()

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,4 +1,7 @@
 import { z } from 'zod'
+import { createLogger } from '../shared/logger/Logger'
+
+const log = createLogger('env')
 
 const DEFAULT_COMMUNICATION_SERVER_URL =
   'https://communication-service-4f4f57e0a956.herokuapp.com'
@@ -82,19 +85,17 @@ function loadEnv(): Env {
   const result = envSchema.safeParse(process.env)
 
   if (!result.success) {
-    console.error('❌ Configuração de ambiente inválida:')
-    for (const issue of result.error.issues) {
-      console.error(`   ${issue.path.join('.')}: ${issue.message}`)
-    }
+    log.error({ issues: result.error.issues }, '❌ Configuração de ambiente inválida')
     process.exit(1)
   }
 
   const data = result.data
-  console.log('[env] Variáveis de ambiente carregadas:')
-  console.log(`  NODE_ENV              = ${data.NODE_ENV}`)
-  console.log(`  GOOGLE_CLIENT_ID      = ${data.GOOGLE_CLIENT_ID ? '✓ configurado' : '✗ ausente'}`)
-  console.log(`  GOOGLE_CLIENT_SECRET  = ${data.GOOGLE_CLIENT_SECRET ? '✓ configurado' : '✗ ausente'}`)
-  console.log(`  YOUTUBE_WATCH_LATER_PLAYLIST_ID = ${data.YOUTUBE_WATCH_LATER_PLAYLIST_ID ? '✓ configurado' : '✗ ausente'}`)
+  log.info({
+    NODE_ENV: data.NODE_ENV,
+    GOOGLE_CLIENT_ID: data.GOOGLE_CLIENT_ID ? '✓ configurado' : '✗ ausente',
+    GOOGLE_CLIENT_SECRET: data.GOOGLE_CLIENT_SECRET ? '✓ configurado' : '✗ ausente',
+    YOUTUBE_WATCH_LATER_PLAYLIST_ID: data.YOUTUBE_WATCH_LATER_PLAYLIST_ID ? '✓ configurado' : '✗ ausente',
+  }, 'Variáveis de ambiente carregadas')
   return data
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,9 @@
 import { Client } from 'discord.js'
 import { appEvents } from './shared/events/AppEvents'
 import { getContextState, saveContextState } from './infrastructure/database/MongoRepository'
+import { createLogger } from './shared/logger/Logger'
+
+const log = createLogger('Context')
 
 export interface AppContext {
     dividas: any[]
@@ -60,7 +63,7 @@ class Context implements AppContext {
 
             appEvents.emit('update-state-jogo-bixo', null)
         } catch (error) {
-            console.log(error)
+            log.error({ err: error }, 'Erro ao carregar estado do contexto')
         }
     }
 

--- a/src/global-exception-handler.ts
+++ b/src/global-exception-handler.ts
@@ -1,8 +1,10 @@
 import captureException from './observability/Sentry'
+import { createLogger } from './shared/logger/Logger'
+
+const log = createLogger('GlobalExceptionHandler')
 
 process.on('uncaughtException', (err: Error) => {
-    console.error('Uncaught Exception:', err.message)
-    console.error(err.stack)
+    log.error({ err }, 'Uncaught Exception')
     captureException(err, true)
     setTimeout(() => {
         process.exit(1)
@@ -10,7 +12,6 @@ process.on('uncaughtException', (err: Error) => {
 })
 
 process.on('unhandledRejection', (err: unknown) => {
-    const e = err as Error
-    console.error('Unhandled Rejection at:', e.stack || err)
+    log.error({ err }, 'Unhandled Rejection')
     captureException(err, true)
 })

--- a/src/handlers/b3/atualizar-cotacao-carteira.ts
+++ b/src/handlers/b3/atualizar-cotacao-carteira.ts
@@ -3,6 +3,9 @@ import axios from 'axios'
 import type { Message } from 'discord.js'
 import fs from 'fs'
 import puppeteer, { type Browser, type Page } from 'puppeteer'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('AtualizarCotacaoCarteira')
 
 const baseUrl = 'https://carteira-14bc707a7fab.herokuapp.com/admin'
 const yahooQuoteUrl = 'https://query1.finance.yahoo.com/v7/finance/quote'
@@ -47,14 +50,13 @@ async function getLogoFromYahoo(papel: string): Promise<string | null> {
       ?.quoteResponse?.result?.[0]
     const url = result?.companyLogoUrl
     if (url && url.startsWith('http')) {
-      console.log('[Yahoo] Logo encontrada para', papel, '->', url)
+      log.debug({ papel, url }, 'Logo encontrada via Yahoo')
       return url
     }
-    console.log('[Yahoo] Sem logo para', papel)
+    log.debug({ papel }, 'Sem logo no Yahoo')
     return null
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    console.log('[Yahoo] Erro ao buscar', papel, msg)
+    log.warn({ err, papel }, 'Erro ao buscar logo no Yahoo')
     return null
   }
 }
@@ -63,7 +65,7 @@ async function getLogoFromYahooWithBrowser(page: Page, papel: string): Promise<s
   const symbol = toYahooSymbol(papel)
   try {
     const url = `https://finance.yahoo.com/quote/${symbol}`
-    console.log('[Yahoo+Puppeteer] Abrindo', url)
+    log.debug({ url }, 'Yahoo+Puppeteer: abrindo página')
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 })
     await new Promise(r => setTimeout(r, 2000))
     const logoUrl = await page.evaluate(() => {
@@ -85,13 +87,12 @@ async function getLogoFromYahooWithBrowser(page: Page, papel: string): Promise<s
       return null
     })
     if (logoUrl) {
-      console.log('[Yahoo+Puppeteer] Logo encontrada para', papel)
+      log.debug({ papel }, 'Yahoo+Puppeteer: logo encontrada')
       return logoUrl
     }
     return null
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    console.log('[Yahoo+Puppeteer] Erro', msg)
+    log.warn({ err, papel }, 'Yahoo+Puppeteer: erro')
     return null
   }
 }
@@ -99,7 +100,7 @@ async function getLogoFromYahooWithBrowser(page: Page, papel: string): Promise<s
 async function imgScrapeBing(page: Page, query: string): Promise<string[] | null> {
   try {
     const searchUrl = `https://www.bing.com/images/search?q=${encodeURIComponent(`${query} ação logo`)}&first=1`
-    console.log('[Bing] Buscando imagens para:', query)
+    log.debug({ query }, 'Bing: buscando imagens')
     await page.goto(searchUrl, { waitUntil: 'networkidle0', timeout: 20000 })
     await page.waitForSelector('.iusc', { timeout: 10000 }).catch(() => null)
     await new Promise(r => setTimeout(r, 1500))
@@ -117,18 +118,17 @@ async function imgScrapeBing(page: Page, query: string): Promise<string[] | null
       })
       return out.slice(0, 5)
     })
-    console.log('[Bing] Encontradas', urls.length, 'imagens para', query)
+    log.debug({ count: urls.length, query }, 'Bing: imagens encontradas')
     return urls.length ? urls : null
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    console.log('[Bing] Erro', msg)
+    log.warn({ err, query }, 'Bing: erro ao buscar imagens')
     return null
   }
 }
 
 async function imgScrapeGoogle(page: Page, query: string): Promise<string[] | null> {
   try {
-    console.log('[Google] Buscando imagens para:', query)
+    log.debug({ query }, 'Google: buscando imagens')
     await page.goto(
       `https://www.google.com/search?tbm=isch&q=${encodeURIComponent(`${query} ação`)}`,
       { waitUntil: 'networkidle2', timeout: 25000 },
@@ -152,11 +152,10 @@ async function imgScrapeGoogle(page: Page, query: string): Promise<string[] | nu
     )
     const images = external.length ? external : thumbnails
     const result = images.slice(0, 3)
-    console.log('[Google] Encontradas', result.length, 'imagens para', query)
+    log.debug({ count: result.length, query }, 'Google: imagens encontradas')
     return result.length ? result : null
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    console.log('[Google] Erro', msg)
+    log.warn({ err, query }, 'Google: erro ao buscar imagens')
     return null
   }
 }
@@ -165,7 +164,7 @@ async function fetchImageWithBrowser(papel: string): Promise<string | null> {
   let browser: Browser | undefined
   let page: Page | undefined
   try {
-    console.log('[Browser] Iniciando...')
+    log.debug('Browser: iniciando Puppeteer')
     browser = await puppeteer.launch(getLaunchOptions())
     page = await browser.newPage()
     await page.setUserAgent(
@@ -184,8 +183,7 @@ async function fetchImageWithBrowser(papel: string): Promise<string | null> {
 
     return null
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    console.error('[Browser] Erro:', msg)
+    log.error({ err }, 'Browser: erro ao buscar imagem')
     return null
   } finally {
     if (page) {
@@ -193,7 +191,7 @@ async function fetchImageWithBrowser(papel: string): Promise<string | null> {
     }
     if (browser) {
       await browser.close()
-      console.log('[Browser] Fechado.')
+      log.debug('Browser: fechado')
     }
   }
 }
@@ -205,14 +203,14 @@ function deleteMessageAfterTime(m: Message): void {
 }
 
 export default async function atualizarCotacaoCarteira(message: Message): Promise<void> {
-  console.log('[atualizar-carteira] Comando iniciado.')
+  log.info('Comando atualizar-carteira iniciado')
   void message.reply('momentinho vou verificar').then(m => deleteMessageAfterTime(m))
 
-  console.log('[atualizar-carteira] Disparando POST', baseUrl)
+  log.debug({ baseUrl }, 'Disparando POST')
   await axios.post(baseUrl)
 
   const { data: listaAtivos } = await axios.get<string[]>(`${baseUrl}/ativos-sem-image`)
-  console.log('[atualizar-carteira] Ativos sem imagem:', listaAtivos.length, listaAtivos)
+  log.info({ count: listaAtivos.length, ativos: listaAtivos }, 'Ativos sem imagem')
   if (listaAtivos.length === 0) {
     void message.reply('nenhum ativo para monitorar').then(m => deleteMessageAfterTime(m))
     return
@@ -221,33 +219,32 @@ export default async function atualizarCotacaoCarteira(message: Message): Promis
   const ativoComImagem: Array<{ papel: string; imagem: string }> = []
   for (const papel of listaAtivos) {
     try {
-      console.log('[atualizar-carteira] Processando papel:', papel)
+      log.info({ papel }, 'Processando papel')
       let imageUrl = await getLogoFromYahoo(papel)
       if (!imageUrl) {
         imageUrl = await fetchImageWithBrowser(papel)
       }
       if (!imageUrl) {
-        console.log('[atualizar-carteira] Sem imagem para', papel)
+        log.warn({ papel }, 'Sem imagem encontrada para o papel')
         void message.channel.send(`Nao consegui adicionar esse papel ${papel}`).then(m => deleteMessageAfterTime(m))
         continue
       }
       ativoComImagem.push({ papel, imagem: imageUrl })
-      console.log('[atualizar-carteira] Imagem obtida para', papel)
+      log.info({ papel }, 'Imagem obtida com sucesso')
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
-      console.error('[atualizar-carteira] Erro ao processar', papel, msg)
+      log.error({ err: e, papel }, 'Erro ao processar papel')
       void message.channel.send(`Nao consegui adicionar esse papel ${papel}`).then(m => deleteMessageAfterTime(m))
     }
   }
 
-  console.log('[atualizar-carteira] Atualizando', ativoComImagem.length, 'ativos na API...')
+  log.info({ count: ativoComImagem.length }, 'Atualizando ativos na API')
   for (const obj of ativoComImagem) {
     await axios.put(`${baseUrl}/atualizar-ativo`, {
       nome: obj.papel,
       imageUrl: obj.imagem,
     })
-    console.log('[atualizar-carteira] API atualizada:', obj.papel)
+    log.info({ papel: obj.papel }, 'API atualizada')
     void message.channel.send(`Atualizado ${obj.papel}`).then(m => deleteMessageAfterTime(m))
   }
-  console.log('[atualizar-carteira] Concluído.')
+  log.info('atualizar-carteira concluído')
 }

--- a/src/handlers/jogo-bixo/game-functions.ts
+++ b/src/handlers/jogo-bixo/game-functions.ts
@@ -3,6 +3,9 @@ import { JOGO_BIXO_CHANNEL } from '../../discord/DiscordConstants'
 import bichos from './bicho'
 import { Jogo, Aposta } from './jogo'
 import { MongoConnection } from '../../infrastructure/database/MongoConnection'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('JogoBixo')
 
 interface GameState {
   jogoAberto: boolean
@@ -38,7 +41,7 @@ function verificarSeTerminouOTempoDeJogo(
 
 function monitorarFimDeJogo(): void {
   state.monitoramentoFimDeJogoRef = setInterval(() => {
-    console.log('verificando se o jogo terminou')
+    log.debug('verificando se o jogo terminou')
     const dataFimJogoMili = state.jogo!.dataInicioDetalhes.hourUTC + state.jogo!.duracao
     const dataAtualDetalhes = { hourUTC: new Date().getUTCHours(), day: new Date().getDay() }
 

--- a/src/handlers/music/index.ts
+++ b/src/handlers/music/index.ts
@@ -6,6 +6,9 @@ import { contextInstance } from '../../context'
 import { textToSpeech } from '../../ia/open-ai-api'
 import { runMusicBuffer } from './play-resource-buffer'
 import { addMusic, ramdomMusic } from '../../services'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('MusicHandler')
 
 const subscriptions = new Map<string, MusicSubscription>()
 let playerLigado = false
@@ -28,7 +31,7 @@ async function playSong(
           adapterCreator: channel.guild.voiceAdapterCreator,
         })
       )
-      subscription.voiceConnection.on('error', console.warn)
+      subscription.voiceConnection.on('error', (err) => log.warn({ err }, 'Voice connection error'))
       subs.set(interaction.guildId, subscription)
     }
   }
@@ -41,24 +44,24 @@ async function playSong(
   try {
     await entersState(subscription.voiceConnection, VoiceConnectionStatus.Ready, 20e3)
   } catch (error) {
-    console.warn(error)
+    log.warn({ err: error }, 'Failed to join voice channel within 20 seconds')
     await interaction.followUp('Failed to join voice channel within 20 seconds, reiniciando processo')
     process.exit(0)
   }
 
   try {
     const track = await Track.from(url, {
-      onStart() { interaction.followUp({ content: 'Now playing!', ephemeral: true }).catch(console.warn) },
-      onFinish() { interaction.followUp({ content: 'Now finished!', ephemeral: true }).catch(console.warn) },
+      onStart() { interaction.followUp({ content: 'Now playing!', ephemeral: true }).catch((err: Error) => log.warn({ err }, 'followUp error')) },
+      onFinish() { interaction.followUp({ content: 'Now finished!', ephemeral: true }).catch((err: Error) => log.warn({ err }, 'followUp error')) },
       onError(error: Error) {
-        console.warn(error)
-        interaction.followUp({ content: `Error: ${error.message}`, ephemeral: true }).catch(console.warn)
+        log.warn({ err: error }, 'Track error')
+        interaction.followUp({ content: `Error: ${error.message}`, ephemeral: true }).catch((err: Error) => log.warn({ err }, 'followUp error'))
       },
     })
     subscription.enqueue(track)
     await interaction.followUp(`Enqueued **${track.title}**`)
   } catch (error: any) {
-    console.warn(error)
+    log.warn({ err: error }, 'Failed to play track')
     let errorMessage = 'Failed to play track, please try again later!'
     if (error.message?.includes('Sign in to confirm')) errorMessage = 'YouTube is temporarily blocking requests. Please try again in a few minutes.'
     else if (error.message?.includes('Video unavailable')) errorMessage = 'This video is unavailable or private.'

--- a/src/handlers/music/play-resource-buffer.ts
+++ b/src/handlers/music/play-resource-buffer.ts
@@ -8,6 +8,9 @@ import {
 } from '@discordjs/voice'
 import connectUserChannel from '../../audio/connect-user-channel'
 import audioPlayer from '../../audio/audio-player'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('PlayResourceBuffer')
 
 async function playMusicByBuffer(buffer: Buffer): Promise<void> {
   const speechFile = path.resolve('./speech.mp3')
@@ -27,6 +30,6 @@ export async function runMusicBuffer(channel: any, buffer: Buffer): Promise<void
     await playMusicByBuffer(buffer)
     connection.subscribe(audioPlayer)
   } catch (error) {
-    console.error(error)
+    log.error({ err: error }, 'Erro ao reproduzir buffer de áudio')
   }
 }

--- a/src/handlers/music/track.ts
+++ b/src/handlers/music/track.ts
@@ -1,6 +1,9 @@
 import { createAudioResource, demuxProbe } from '@discordjs/voice'
+import { createLogger } from '../../shared/logger/Logger'
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { exec } = require('youtube-dl-exec')
+
+const log = createLogger('Track')
 
 const noop = (): void => { }
 
@@ -50,7 +53,7 @@ export class Track {
       const stream = process.stdout
       const onError = (error: Error): void => {
         if (!process.killed) process.kill()
-        console.log(error)
+        log.error({ err: error }, 'Audio resource error')
         stream.resume()
         reject(error)
       }
@@ -86,7 +89,7 @@ export class Track {
         break
       } catch (error: any) {
         retryCount++
-        console.warn(`youtube-dl-exec attempt ${retryCount} failed:`, error.message)
+        log.warn({ err: error, retryCount }, `youtube-dl-exec attempt ${retryCount} failed`)
         if (retryCount >= maxRetries) throw new Error('Failed to get video information. Please try again later.')
         await new Promise(r => setTimeout(r, 1000 * retryCount))
       }

--- a/src/handlers/real-time-conversa/index.ts
+++ b/src/handlers/real-time-conversa/index.ts
@@ -5,6 +5,9 @@ import { contextInstance } from '../../context'
 import { speechToText, textCompletion, textToSpeech } from '../../ia/open-ai-api'
 import { runMusicBuffer } from '../music/play-resource-buffer'
 import { convertOggToMp3 } from '../../services/upload/CloudConvertService'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('RealTimeConversa')
 
 const listeningUsersId = new Set<string>()
 let channelRef: any = null
@@ -35,7 +38,7 @@ async function respond(filename: string): Promise<void> {
     await runMusicBuffer(channelRef, audioBuffer)
   } catch (error: any) {
     logMessageOnLixoChannel(`deu pau :/ ${error.message}`)
-    console.error(error)
+    log.error({ err: error }, 'Erro no ciclo de conversa em tempo real')
   }
 }
 
@@ -57,7 +60,7 @@ const realTimeConversaHandler = (message: any): void => {
     return
   }
   channelRef = channel
-  connectUserChannel(channel).then(listening).catch(console.error)
+  connectUserChannel(channel).then(listening).catch((err: Error) => log.error({ err }, 'Erro ao conectar ao canal de voz'))
 }
 
 export default realTimeConversaHandler

--- a/src/handlers/record/record-audio.ts
+++ b/src/handlers/record/record-audio.ts
@@ -2,8 +2,11 @@ import path from 'path'
 import { contextInstance } from '../../context'
 import connectUserChannel from '../../audio/connect-user-channel'
 import ListeningStream from '../../audio/listening-audio-stream'
+import { createLogger } from '../../shared/logger/Logger'
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const audioconcat = require('audioconcat')
+
+const log = createLogger('RecordAudio')
 
 const recordable = new Set<string>()
 const files = new Set<string>()
@@ -22,12 +25,11 @@ function concatAudios(): void {
 
   audioconcat(songs)
     .concat(filenameOutput)
-    .on('start', (command: string) => console.log('ffmpeg process started:', command))
+    .on('start', (command: string) => log.debug({ command }, 'ffmpeg process started'))
     .on('error', (err: Error, _stdout: unknown, stderr: string) => {
-      console.error('Error:', err)
-      console.error('ffmpeg stderr:', stderr)
+      log.error({ err, stderr }, 'ffmpeg error')
     })
-    .on('end', () => console.log('✅ Audio created in:', filenameOutput))
+    .on('end', () => log.info({ filenameOutput }, 'Audio created'))
 }
 
 const recordAudioHandler = async (args: string[], message: any): Promise<void> => {
@@ -43,7 +45,7 @@ const recordAudioHandler = async (args: string[], message: any): Promise<void> =
 
       receiver.speaking.on('start', (userId: string) => {
         if (recordable.has(userId)) {
-          console.log('nao gravar o autor do comando')
+          log.debug({ userId }, 'nao gravar o autor do comando')
         } else {
           ListeningStream(receiver, userId, (client as any).users.cache.get(userId), addFile)
         }
@@ -57,7 +59,7 @@ const recordAudioHandler = async (args: string[], message: any): Promise<void> =
         concatAudios()
       }, timeoutMillis)
     } catch (error) {
-      console.error(error)
+      log.error({ err: error }, 'Erro ao gravar audio')
     }
   } else {
     message.reply('Join a voice channel then try again!')

--- a/src/handlers/record/upload-records.ts
+++ b/src/handlers/record/upload-records.ts
@@ -2,6 +2,9 @@ import { contextInstance } from '../../context'
 import { googleOAuthState } from '../../adapters/google-Oauth'
 import { google } from 'googleapis'
 import fs from 'fs'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('UploadRecords')
 
 const TOKEN_PATH = 'token.json'
 
@@ -34,13 +37,13 @@ const uploadRecordsHandler = (message: any): void => {
 
     drive.files.create({ requestBody: fileMetadata, fields: 'id' } as any, (err: any, file: any) => {
       if (err) {
-        console.error(err)
+        log.error({ err }, 'nao consegui criar o folder no drive')
         message.reply('nao consegui criar o folder no drive')
         fs.rm(TOKEN_PATH, () => { })
         return
       }
 
-      console.log('Folder Id: ', file.data.id)
+      log.info({ folderId: file.data.id }, 'Folder criado no Drive')
       for (const item of contextInstance().gravacoes) {
         drive.files.create(
           {
@@ -49,8 +52,8 @@ const uploadRecordsHandler = (message: any): void => {
             fields: 'id',
           } as any,
           (err2: any) => {
-            if (err2) { console.error(err2); fs.rm(TOKEN_PATH, () => { }) }
-            else { console.log('up'); message.reply('subi pai') }
+            if (err2) { log.error({ err: err2 }, 'Erro ao fazer upload do arquivo'); fs.rm(TOKEN_PATH, () => { }) }
+            else { log.info({ item }, 'Arquivo enviado com sucesso'); message.reply('subi pai') }
           }
         )
       }

--- a/src/ia/index.ts
+++ b/src/ia/index.ts
@@ -1,6 +1,9 @@
 import { buildMessageElements } from './watson-utils'
 import { textCompletion } from './open-ai-api'
 import { env } from '../config/env'
+import { createLogger } from '../shared/logger/Logger'
+
+const log = createLogger('IA')
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const AssistantV2 = require('ibm-watson/assistant/v2')
@@ -22,20 +25,20 @@ async function fallbackToChatGpt(message: any): Promise<void> {
     const reply = response.choices[0]?.message.content.trim() ?? ''
     await message.channel.send(reply)
   } catch (err) {
-    console.error('ChatGPT fallback error', err)
+    log.error({ err }, 'ChatGPT fallback error')
     await message.channel.send('Não consegui processar sua mensagem.')
     void args
   }
 }
 
 function createSession(callback: () => void = () => { }): void {
-  console.warn('criando sessao no watson')
+  log.warn('criando sessao no watson')
   assistant.createSession({ assistantId: env.ASSISTANT_ID })
     .then((response: any) => {
       state.sessionId = response.result.session_id
       callback()
     })
-    .catch((err: unknown) => console.error('erro ao pegar sessao no watson', err))
+    .catch((err: unknown) => log.error({ err }, 'erro ao pegar sessao no watson'))
 }
 
 function sendMessage(message: any): void {
@@ -64,7 +67,7 @@ function sendMessage(message: any): void {
     })
     .catch((err: unknown) => {
       state.sessionId = undefined
-      console.error('erro ao enviar mensagem', err)
+      log.error({ err }, 'erro ao enviar mensagem')
     })
 }
 

--- a/src/observability/Sentry.ts
+++ b/src/observability/Sentry.ts
@@ -1,5 +1,8 @@
 import * as Sentry from '@sentry/node'
 import { env } from '../config/env'
+import { createLogger } from '../shared/logger/Logger'
+
+const log = createLogger('Sentry')
 
 const SENTRY_DNS: string | undefined = env.SENTRY_DNS
 
@@ -29,7 +32,7 @@ function captureException(ex: unknown, alreadyLogged = false): void {
 
     if (err['isAxiosError']) {
         const axiosErr = ex as AxiosErrorLike
-        console.error('HTTP Axios Error: ', {
+        log.error({
             message: axiosErr.message,
             name: axiosErr.name,
             code: axiosErr.code,
@@ -42,13 +45,13 @@ function captureException(ex: unknown, alreadyLogged = false): void {
                       data: axiosErr.response.data,
                   }
                 : null,
-        })
+        }, 'HTTP Axios Error')
     } else if (!alreadyLogged) {
-        console.error('Unknown Error: ', {
+        log.error({
             message: err['message'],
             name: err['name'],
             stack: err['stack'],
-        })
+        }, 'Unknown Error')
     }
 
     if (SENTRY_DNS) {

--- a/src/scheduler/jobs/MidnightJob.ts
+++ b/src/scheduler/jobs/MidnightJob.ts
@@ -2,6 +2,9 @@ import { IJob } from '../IJob'
 import { CHAT_GERAL, CANAIS_PARA_LIMPAR } from '../../discord/DiscordConstants'
 import { contextInstance } from '../../context'
 import { rankearUso, rotinaDiariaCrypto } from '../../services'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('MidnightJob')
 
 /**
  * Runs daily at 23:10.
@@ -30,8 +33,8 @@ export class MidnightJob implements IJob {
     for (const channelName of CANAIS_PARA_LIMPAR) {
       const ch = channels.find((c: any) => c.name === channelName)
       ch?.bulkDelete(30)
-        .then((messages: any) => console.log(`Bulk deleted ${messages.size} messages ${new Date()}`))
-        .catch((reason: unknown) => console.log(reason))
+        .then((messages: any) => log.info({ count: messages.size }, 'Bulk delete concluído'))
+        .catch((reason: unknown) => log.error({ err: reason }, 'Erro ao deletar mensagens em massa'))
     }
   }
 }

--- a/src/scheduler/jobs/YoutubeRssJob.ts
+++ b/src/scheduler/jobs/YoutubeRssJob.ts
@@ -4,6 +4,9 @@ import { isFeriadoHoje } from '../../shared/utils/feriados-br'
 import { saveYoutubeVideos } from '../../infrastructure/database/MongoRepository'
 import { youtubeRssService, sendToChannel } from '../../services'
 import { appEvents } from '../../shared/events/AppEvents'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('YoutubeRssJob')
 
 /**
  * Runs daily at 08:16, Monday to Saturday. Skips Brazilian holidays.
@@ -23,7 +26,7 @@ export class YoutubeRssJob implements IJob {
       
     } catch (err) {
       const msg = `[YouTube RSS] Erro no processamento: ${(err as Error).message}`
-      console.error(msg, err)
+      log.error({ err }, msg)
       sendToChannel(LIXO_CHANNEL, msg)
     }
   }

--- a/src/services/ConversationHistoryGpt.ts
+++ b/src/services/ConversationHistoryGpt.ts
@@ -1,5 +1,8 @@
 import { contextInstance } from '../context'
 import { textCompletion } from '../ia/open-ai-api'
+import { createLogger } from '../shared/logger/Logger'
+
+const log = createLogger('ConversationHistoryGpt')
 
 const MAX_LENGTH = 2000
 
@@ -32,7 +35,7 @@ function continueConversation(conversationHistory: any, newMessage: string): voi
       conversationHistory.messages.push({ role: 'assistant', content: chatGPTResponse })
       gptResponseDisplay(conversationHistory.thread, chatGPTResponse)
     })
-    .catch((err: unknown) => console.error('ConversationHistoryGpt error', err))
+    .catch((err: unknown) => log.error({ err }, 'ConversationHistoryGpt error'))
 }
 
 const conversationHistoryGpt = (message: any): void => {

--- a/src/services/b3/AutoArbitrageService.ts
+++ b/src/services/b3/AutoArbitrageService.ts
@@ -1,5 +1,8 @@
 import { contextInstance } from '../../context'
 import { asyncArbitrage, forceArbitrage } from './CryptoArbitrageService'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('AutoArbitrageService')
 
 const state = {
     isRunning: false,
@@ -39,7 +42,7 @@ export function startAutomateAfterNewSubscription(): void {
     }
 
     forceArbitrage(155, (message: string) => {
-        console.log(message)
+        log.info({ message }, 'Arbitragem forçada após nova assinatura')
     })
 }
 
@@ -50,6 +53,6 @@ export function startAutoArbitrage(): void {
 
     const quantities = randomNumberUntil(100)
     state.quantities = quantities
-    console.log(`Iniciando arbitragem com ${quantities} requisições`)
+    log.info({ quantities }, 'Iniciando arbitragem')
     execute(0)
 }

--- a/src/services/b3/CryptoArbitrageService.ts
+++ b/src/services/b3/CryptoArbitrageService.ts
@@ -2,6 +2,9 @@ import axios from 'axios'
 import { contextInstance } from '../../context'
 import { enviarAlertaParaUsuario } from '../../telegram/handlers/PublicHandler'
 import { sendEmail } from '../email/EmailService'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('CryptoArbitrageService')
 
 const URLS = {
     primary: 'https://crypto-svc-eur-0e4c4365b070.herokuapp.com',
@@ -17,7 +20,7 @@ async function makeRequest(
     data: any = null,
     options: Record<string, any> = {}
 ): Promise<any> {
-    console.log(method, ' . . ', `${currentUrl}${endpoint}`)
+    log.debug({ method, url: `${currentUrl}${endpoint}` }, 'HTTP request')
 
     const config: Record<string, any> = {
         method,
@@ -35,7 +38,7 @@ async function makeRequest(
         return response
     } catch (error: any) {
         if (error.response?.status === 503 && currentUrl === URLS.primary) {
-            console.log('Erro 503 detectado, trocando para URL reserva')
+            log.warn('Erro 503 detectado, trocando para URL reserva')
             currentUrl = URLS.backup
             return makeRequest(method, endpoint, data, options)
         }
@@ -47,9 +50,9 @@ function forceFutureArbitrage(): void {
     setTimeout(async () => {
         try {
             const response = await makeRequest('POST', '/v1/arbitrage/future')
-            console.log(response.data)
+            log.debug({ data: response.data }, 'Future arbitrage response')
         } catch (error) {
-            console.log(error)
+            log.error({ err: error }, 'Erro no future arbitrage')
         }
     }, 7000)
 }
@@ -93,7 +96,7 @@ async function executeSingleArbitrage(): Promise<void> {
         }
         forceFutureArbitrage()
     } catch (error: any) {
-        console.log('Error during arbitrage execution:', error.message)
+        log.error({ err: error }, 'Error during arbitrage execution')
     }
 }
 
@@ -103,7 +106,7 @@ async function runArbitrageTick(): Promise<void> {
         return
     }
 
-    console.log(`Executando arbitragem (${pendingArbitrageCount} restantes na fila)`)
+    log.info({ pendingArbitrageCount }, 'Executando arbitragem')
     await executeSingleArbitrage()
     pendingArbitrageCount--
 
@@ -134,7 +137,7 @@ export async function getHighYieldStatistics(): Promise<void> {
         const response = await makeRequest('GET', '/v1/statistics/high-yield-report')
         processStatisticsResponse(response.data)
     } catch (error: any) {
-        console.log('Erro na requisição:', error.message)
+        log.error({ err: error }, 'Erro ao buscar high yield statistics')
     }
 }
 
@@ -173,7 +176,7 @@ export async function getMediaSpread(): Promise<void> {
             `A média do spread é de ${response.data.average_spread.toFixed(2)}%`
         )
     } catch (error: any) {
-        console.log('Erro na requisição:', error.message)
+        log.error({ err: error }, 'Erro ao buscar media spread')
     }
 }
 
@@ -182,7 +185,7 @@ export async function getRankingExchanges(): Promise<any> {
         const response = await makeRequest('GET', '/v1/statistics/ranking')
         return response.data
     } catch (error: any) {
-        console.log('Erro na requisição:', error.message)
+        log.error({ err: error }, 'Erro ao buscar ranking exchanges')
         return null
     }
 }
@@ -190,9 +193,9 @@ export async function getRankingExchanges(): Promise<any> {
 export async function gerarRankingExchanges(): Promise<void> {
     try {
         await makeRequest('POST', '/v1/statistics/top3')
-        console.log('Ranking gerado com sucesso!')
+        log.info('Ranking gerado com sucesso')
     } catch (error: any) {
-        console.log('Erro na requisição:', error.message)
+        log.error({ err: error }, 'Erro ao gerar ranking exchanges')
     }
 }
 
@@ -245,9 +248,9 @@ async function consultar(id: string): Promise<void> {
         enviarMensagemAvisoCrypto(message)
     } catch (error: any) {
         if (error.code === 'ECONNABORTED') {
-            console.log('A requisição foi abortada por exceder o tempo limite de 4 segundos.')
+            log.warn({ id }, 'A requisição foi abortada por exceder o tempo limite')
         } else {
-            console.log('Erro na requisição:', error.message)
+            log.error({ err: error, id }, 'Erro ao consultar arbitragem')
         }
     }
 }
@@ -255,7 +258,7 @@ async function consultar(id: string): Promise<void> {
 function enviarMensagemDiscord(message: string): void {
     const ctx = contextInstance()
     if (!ctx) {
-        console.warn('[Discord] Context ainda não inicializado, mensagem ignorada.')
+        log.warn('Context Discord ainda não inicializado, mensagem ignorada')
         return
     }
     ctx.emitEvent('enviar-mensagem-discord', { message })
@@ -264,7 +267,7 @@ function enviarMensagemDiscord(message: string): void {
 function enviarMensagemTelegram(message: string): void {
     const ctx = contextInstance()
     if (!ctx) {
-        console.warn('[Telegram] Context ainda não inicializado, mensagem ignorada.')
+        log.warn('Context Telegram ainda não inicializado, mensagem ignorada')
         return
     }
     ctx.emitEvent('enviar-mensagem-telegram', { message, chatId: GROUP_ID })
@@ -301,7 +304,7 @@ export function processAMQPMessage(message: any, routingKey: string): void {
             break
         }
         case 'ALERT_SMS_PRIVATE_USER':
-            console.log(jsonContent?.content)
+            log.info({ content: jsonContent?.content }, 'ALERT_SMS_PRIVATE_USER recebido')
             break
     }
 }

--- a/src/services/finance/CaixinhaService.ts
+++ b/src/services/finance/CaixinhaService.ts
@@ -8,6 +8,9 @@ import { sendEmail } from '../email/EmailService'
 import { addSubcriptionByEvent, addProtestByEvent } from '../subscription/SubscriptionService'
 import { forceArbitrage } from '../b3/CryptoArbitrageService'
 import { appEvents } from '../../shared/events/AppEvents'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('CaixinhaService')
 
 function getFinanceService() {
     return require('./FinanceService').default ?? require('./FinanceService')
@@ -42,7 +45,7 @@ async function notifySms(payload: { message: string; phone?: string }): Promise<
                 desc: message,
                 recipients: [phone]
             })
-            console.log(response.data)
+            log.debug({ data: response.data }, 'SMS enviado')
             return
         }
 
@@ -51,7 +54,7 @@ async function notifySms(payload: { message: string; phone?: string }): Promise<
             desc: message,
             user: 'jeanlucafp@gmail.com'
         })
-        console.log(response.data)
+        log.debug({ data: response.data }, 'SMS enviado')
     } catch (error) {
         captureException(error)
     }

--- a/src/services/finance/DailyBudgetService.ts
+++ b/src/services/finance/DailyBudgetService.ts
@@ -5,6 +5,9 @@ import { formatDate } from '../../shared/utils/discord-nicks-default'
 import { sleep, nowInSaoPaulo } from '../../shared/utils/utils'
 import { sendEmail } from '../email/EmailService'
 import { adicionarGasto, LIMIT } from './GastosCartaoService'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('DailyBudgetService')
 
 function getOrganizzeService() {
     return require('../finance/OrganizzeService').default ?? require('../finance/OrganizzeService')
@@ -53,7 +56,7 @@ async function categorizar(transactionData: { description: string }): Promise<an
     const descriptionCategories = state.categories.map(category => category.name)
     const { categorizarTransacao } = getTransactionCategorizationService()
     const result = await categorizarTransacao(descriptionCategories, transactionData.description)
-    console.log('result categorizar', result)
+    log.debug({ result }, 'result categorizar')
     return result
 }
 
@@ -249,7 +252,7 @@ export async function fillDaylyBudgetState(): Promise<void> {
             state.budget = (data[0] as any).budget
         }
 
-        console.log(collectionName, 'filled', 'new balance:', state.budget!.toFixed(2))
+        log.info({ collection: collectionName, balance: state.budget!.toFixed(2) }, 'Daily budget carregado')
     } catch (error) {
         captureException(error)
         throw new Error('Cannot load daily budget')
@@ -325,7 +328,7 @@ function calcularDiasAteHoje(data: Date): number {
 function processarHistoricoTransacoes(result: any[]): void {
     if (result.length === 0) return
 
-    console.log(`${collectionTransactionName} quantidade `, result.length)
+    log.info({ collection: collectionTransactionName, count: result.length }, 'Transacoes encontradas')
     const ultimoElemento = result[0]
     const diasAteHoje = calcularDiasAteHoje(ultimoElemento.date)
     const totalDespesas = result.map(it => Number(it.money)).reduce((sum, v) => sum + v, 0)
@@ -433,7 +436,7 @@ export async function spentMoney({
     description: string
 }): Promise<number | undefined> {
     money = Number(money)
-    console.log('spent money', money)
+    log.debug({ money }, 'spent money')
     if (isNaN(money)) {
         return
     }
@@ -449,7 +452,7 @@ export async function spentMoney({
 
 export function addMoneyToDailyBudget(money: number | string): number | undefined {
     money = Number(money)
-    console.log('add Money To Daily Budget', money)
+    log.debug({ money }, 'add Money To Daily Budget')
     if (isNaN(money)) {
         return
     }

--- a/src/services/finance/FinanceService.ts
+++ b/src/services/finance/FinanceService.ts
@@ -4,6 +4,9 @@ import { env } from '../../config/env'
 import { contextInstance } from '../../context'
 import captureException from '../../observability/Sentry'
 import { CAIXINHA_CHANNEL } from '../../discord/DiscordConstants'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('FinanceService')
 
 const MAX_RETRY_TENTATIVES = 10
 
@@ -164,7 +167,7 @@ export default function handleFinanceMessage(message: { subtype: string; data: a
             cobrancaImediata(message.data)
             break
         default:
-            console.log('no function for handle')
+            log.warn({ subtype: message.subtype }, 'Nenhuma função mapeada para o subtype')
             break
     }
 }

--- a/src/services/subscription/SubscriptionService.ts
+++ b/src/services/subscription/SubscriptionService.ts
@@ -6,6 +6,9 @@ import { sendEmail } from '../email/EmailService'
 import captureException from '../../observability/Sentry'
 import { LIXO_CHANNEL } from '../../discord/DiscordConstants'
 import { startAutomateAfterNewSubscription } from '../b3/AutoArbitrageService'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('SubscriptionService')
 
 async function migrateCollections(token: string): Promise<{ message: string; total: number }> {
     const config = {
@@ -199,7 +202,7 @@ async function cancelSubscription(email: string): Promise<void> {
     }
 
     await axios.request(config)
-    console.log(`Assinatura cancelada com sucesso para: ${email}`)
+    log.info({ email }, 'Assinatura cancelada com sucesso')
 }
 
 function sendCancellationEmail(name: string, email: string): void {
@@ -224,7 +227,7 @@ export async function addProtestByEvent(event: any): Promise<void> {
         await cancelSubscription(email)
         notifyDiscordCancellation(name, email)
     } catch (error: any) {
-        console.error(`Erro ao cancelar assinatura para ${email}:`, error.message)
+        log.error({ err: error, email }, 'Erro ao cancelar assinatura')
         captureException(error)
     }
 }

--- a/src/services/whatsapp/AddressExtractionService.ts
+++ b/src/services/whatsapp/AddressExtractionService.ts
@@ -3,6 +3,9 @@ import { StructuredOutputParser } from 'langchain/output_parsers'
 import { ChatPromptTemplate } from '@langchain/core/prompts'
 import { z } from 'zod'
 import { env } from '../../config/env'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('AddressExtractionService')
 
 export const AddressSchema = z.object({
   cep: z.string().optional().describe('CEP quando mencionado'),
@@ -43,7 +46,7 @@ export async function extractAddressFromText(text: string): Promise<Address | nu
     })
     return result as Address
   } catch (e) {
-    console.error('addressExtractionService error', e)
+    log.error({ err: e }, 'addressExtractionService error')
     return null
   }
 }

--- a/src/telegram/handlers/DailyBudgetHandler.ts
+++ b/src/telegram/handlers/DailyBudgetHandler.ts
@@ -7,6 +7,9 @@ import {
   spentMoney,
 } from '../../services/finance/DailyBudgetService'
 import { KEYBOARDS } from '../TelegramConfig'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('DailyBudgetHandler')
 
 const state = {
   awaitResponseSpentMoney: false,
@@ -71,7 +74,7 @@ export function registerDailyBudgetHandlers(bot: any): void {
       const budget = await spentMoney({ money, description })
       ctx.reply(`your new daily budget is R$ ${budget}`)
     } catch (err) {
-      console.error('Error processing spent money:', err)
+      log.error({ err }, 'Error processing spent money')
       ctx.reply('An error occurred. Please try again.')
     } finally {
       state.awaitResponseSpentMoney = false

--- a/src/telegram/handlers/PublicHandler.ts
+++ b/src/telegram/handlers/PublicHandler.ts
@@ -4,6 +4,9 @@ import { enviarMensagemParaMim, enviarMensagemParaUsuario } from '../TelegramUti
 import { getSubscriptionByEmailAllTenants } from '../../services/subscription/SubscriptionValidator'
 import { MongoConnection } from '../../infrastructure/database/MongoConnection'
 import { KEYBOARDS, SUBSCRIPTION_PURCHASE_URL } from '../TelegramConfig'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('PublicHandler')
 
 // ── Tipos ─────────────────────────────────────────────────────────────────
 
@@ -31,7 +34,7 @@ function setUserState(userId: number, state: string): void { userStates.set(user
 
 function getCollection() {
   const db = MongoConnection.getDb()
-  if (!db) { console.error('MongoDB não conectado'); return null }
+  if (!db) { log.error('MongoDB não conectado'); return null }
   return db.collection<TelegramUser>('telegram-users')
 }
 
@@ -160,10 +163,10 @@ async function findUserByEmail(email: string): Promise<TelegramUser | null> {
 
 export async function enviarAlertaParaUsuario(content: { email: string; message: string }): Promise<{ success: boolean; userId?: number } | void> {
   const { email, message } = content
-  if (!email || !message) { console.error('[Telegram] Email ou mensagem não fornecidos'); return }
+  if (!email || !message) { log.error('Email ou mensagem não fornecidos'); return }
   const user = await findUserByEmail(email)
-  if (!user) { console.log(`[Telegram] Usuário com email ${email} não encontrado`); return }
-  if (!user.isActive) { console.log(`[Telegram] Usuário ${email} sem assinatura ativa`); return }
+  if (!user) { log.info({ email }, 'Usuário não encontrado'); return }
+  if (!user.isActive) { log.info({ email }, 'Usuário sem assinatura ativa'); return }
   await enviarMensagemParaUsuario(user.userId, message)
   return { success: true, userId: user.userId }
 }


### PR DESCRIPTION
Remove todos os console.log/error/warn/info/debug espalhados (110 ocorrências
em 28 arquivos) e substitui pelo logger centralizado já existente em
src/shared/logger/. Cada módulo agora usa createLogger('NomeModulo') para
emitir logs estruturados com contexto (module, campos relevantes, msg).

- Em dev: saída colorida via pino-pretty
- Em prod: JSON puro, pronto para ingestão em ferramentas de observabilidade
- Erros passam { err } como objeto estruturado (padrão pino)
- Mensagens de debug rebaixadas para log.debug onde aplicável

https://claude.ai/code/session_01LrrW9s7AFsMSb3tjLpqcvs