### PR TITLE
fix: guard null API responses in CryptoArbitrageService and stop dyno-killing process.exit in MusicHandler

### DIFF
--- a/src/handlers/music/index.ts
+++ b/src/handlers/music/index.ts
@@ -45,8 +45,12 @@ async function playSong(
     await entersState(subscription.voiceConnection, VoiceConnectionStatus.Ready, 20e3)
   } catch (error) {
     log.warn({ err: error }, 'Failed to join voice channel within 20 seconds')
-    await interaction.followUp('Failed to join voice channel within 20 seconds, reiniciando processo')
-    process.exit(0)
+    try {
+      subscription.voiceConnection.destroy()
+    } catch (_) { /* ignore destroy errors */ }
+    subs.delete(interaction.guildId)
+    await interaction.followUp('Não foi possível conectar ao canal de voz. Tente novamente.')
+    return
   }
 
   try {

--- a/src/services/b3/CryptoArbitrageService.ts
+++ b/src/services/b3/CryptoArbitrageService.ts
@@ -142,6 +142,11 @@ export async function getHighYieldStatistics(): Promise<void> {
 }
 
 function processStatisticsResponse(data: any): void {
+    if (!data || !data.crypto_stats || !data.top_3_exchanges) {
+        log.warn({ data }, 'processStatisticsResponse: dados inválidos ou nulos, ignorando')
+        return
+    }
+
     const { crypto_stats, top_3_exchanges, total_operations, period } = data
 
     let cryptoMessage = `📊 *Estatísticas por Crypto (${period})*\n\n`
@@ -330,6 +335,10 @@ export function rotinaDiariaCrypto(): void {
 
     setTimeout(async () => {
         getRankingExchanges().then((data: any) => {
+            if (!data) {
+                log.warn('rotinaDiariaCrypto: ranking exchanges retornou nulo, ignorando')
+                return
+            }
             evidenciarRankingExchanges(data)
         })
     }, 15000)


### PR DESCRIPTION
## Summary

- **CryptoArbitrageService** — `processStatisticsResponse` now early-returns with a warning when the API response is `null` or missing `crypto_stats`/`top_3_exchanges`, preventing the recurring `TypeError: Cannot read properties of null (reading 'forEach')` seen on 23/04–28/04.
- **CryptoArbitrageService** — `rotinaDiariaCrypto` now guards against a `null` return from `getRankingExchanges` before calling `evidenciarRankingExchanges`, fixing the unhandled `TypeError: Cannot read properties of null (reading 'filter')` (25/04–26/04).
- **MusicHandler** — replaced `process.exit(0)` on voice-channel join timeout with a graceful cleanup (destroy connection, remove from subscriptions map, reply to user). This stops the 20-second voice timeout from crashing the Heroku dyno and triggering a restart loop (28/04).

## Test plan

- [ ] Trigger `getHighYieldStatistics` when the crypto API is down / returns an empty body — confirm only a `warn` log appears, no crash.
- [ ] Trigger `rotinaDiariaCrypto` when the ranking endpoint returns `null` — confirm only a `warn` log appears.
- [ ] Use `/play` in a server where the bot cannot join the voice channel — confirm it replies with the error message and stays online instead of restarting.

https://claude.ai/code/session_01FyXRthz2ENEUri1oGZAgdd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyXRthz2ENEUri1oGZAgdd)_