### PR TITLE
fix: corrige bug no comando $bg que nunca retornava transações

### DIFF
--- a/src/services/finance/DailyBudgetService.ts
+++ b/src/services/finance/DailyBudgetService.ts
@@ -171,8 +171,12 @@ async function gastosDoUltimoFimDeSemana(): Promise<any[]> {
 async function consultarTransacoesDoDiaForaDaCompetencia(
     dataProcurada: Date
 ): Promise<string[]> {
+    const startOfDay = new Date(dataProcurada)
+    startOfDay.setHours(0, 0, 0, 0)
+    const endOfDay = new Date(dataProcurada)
+    endOfDay.setHours(23, 59, 59, 999)
     const data = await searchTransactions({
-        date: { $gte: dataProcurada, $lte: dataProcurada }
+        date: { $gte: startOfDay, $lte: endOfDay }
     })
 
     return data


### PR DESCRIPTION
$(cat <<'EOF'
## Problema

O comando `$bg <DD/MM>` sempre retornava "Não há transações para esta data" mesmo com registros no banco.

## Causa raiz

Em `DailyBudgetService.ts`, a função `consultarTransacoesDoDiaForaDaCompetencia` usava o seguinte filtro MongoDB:

```js
date: { $gte: dataProcurada, $lte: dataProcurada }
```

Como `$gte` e `$lte` tinham o mesmo valor (meia-noite do dia procurado), o filtro só casaria com documentos cujo `date` fosse **exatamente** a meia-noite — impossível para transações reais que têm timestamps durante o dia (ex: `2026-04-09T13:16:27`).

## Correção

Substituído pelo intervalo correto de início e fim do dia:

```js
const startOfDay = new Date(dataProcurada)
startOfDay.setHours(0, 0, 0, 0)
const endOfDay = new Date(dataProcurada)
endOfDay.setHours(23, 59, 59, 999)
date: { $gte: startOfDay, $lte: endOfDay }
```

## Test plan

- [ ] `$bg 9/4` deve retornar as transações do dia 09/04/2026
- [ ] `$bg 10/4` deve retornar as transações do dia 10/04/2026
- [ ] `$bg 1/1` em um dia sem transações deve continuar retornando "Não há transações para esta data"
- [ ] `$bg 9/4/2026` (formato com ano explícito) deve funcionar igualmente

https://claude.ai/code/session_01Utv96vFvXWWiJYFFWtHZLS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Utv96vFvXWWiJYFFWtHZLS)_