### PR TITLE
feat: add food-spending admin command

### DIFF
--- a/src/commands/lista-comandos.ts
+++ b/src/commands/lista-comandos.ts
@@ -4,7 +4,7 @@ import { addDailyBudgetHandler, updateGastosCartaoHandler, relatorioMensalDeGast
 import { jogoBixoHandler, estatisticasJogoBixoHandler } from '../discord/commands/game'
 import { chatGpt, changeIaMode } from '../discord/commands/ai'
 import { arbitragemHandler, changeAutoArbitragemHandler, crossingCountsHandler, atualizarCotacaoHandler } from '../discord/commands/b3'
-import { restartHandler, dbCleanHandler, meconecteiHandler, updateInterestHandler } from '../discord/commands/admin'
+import { restartHandler, dbCleanHandler, meconecteiHandler, updateInterestHandler, foodSpendingHandler } from '../discord/commands/admin'
 import { assinaturasHandler, assinaturasAtivasHandler } from '../discord/commands/subscriptions'
 import { helpHandler, imgurHandler } from '../discord/commands/media'
 import { configWhatsAppHandler, clearWhatsAppHandler, testWhatsAppHandler } from '../discord/commands/whatsapp'
@@ -41,6 +41,7 @@ registrarComando('rs', restartHandler, 'Reinicia a aplicação (admin)')
 registrarComando('db-clean', dbCleanHandler, 'Limpa banco crypto (admin)')
 registrarComando('meconectei', meconecteiHandler, 'Cria conta admin no Me Conectei :: $meconectei <email> (admin)', true)
 registrarComando('atualizar-juros', updateInterestHandler, 'Atualiza o gasto mensal de juros e envia e-mail ao admin (admin)')
+registrarComando('food-spending', foodSpendingHandler, 'Atualiza o gasto mensal com alimentação e envia e-mail ao admin (admin)')
 registrarComando('sub', assinaturasHandler, 'Cria assinatura de 30 dias :: $sub <email> (admin)', true)
 registrarComando('ass', assinaturasAtivasHandler, 'Lista assinaturas ativas (admin)')
 registrarComando('rec', recordHandler, 'Grava áudio :: $rec <segundos>', true)

--- a/src/discord/commands/admin/FoodSpendingCommand.ts
+++ b/src/discord/commands/admin/FoodSpendingCommand.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+import { BaseCommand, DiscordMessage } from '../BaseCommand'
+import { createLogger } from '../../../shared/logger/Logger'
+import { getFoodSpending, updateFoodSpending } from '../../../services/finance/OrganizzeService'
+import { sendEmail } from '../../../services/email/EmailService'
+import { ADMIN_EMAIL } from '../../../config/constants'
+
+const log = createLogger('FoodSpendingCommand')
+const schema = z.tuple([]).rest(z.string())
+
+const MESES = [
+  'janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho',
+  'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro',
+]
+
+function formatBRL(cents: number): string {
+  const reais = (cents / 100).toFixed(2)
+  const [intPart = '0', decPart = '00'] = reais.split('.')
+  const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, '.')
+  return `R$ ${intFormatted},${decPart}`
+}
+
+export class FoodSpendingCommand extends BaseCommand<typeof schema> {
+  readonly name = 'food-spending'
+  readonly description = 'Atualiza o gasto mensal com alimentação e envia e-mail ao admin'
+  protected readonly schema = schema
+
+  protected async handle(message: DiscordMessage): Promise<void> {
+    await message.reply('Buscando dados de gastos com alimentação...')
+
+    const foodSpending = await getFoodSpending()
+    const { total_cents, year, month, items } = foodSpending
+
+    log.info({ total_cents, year, month, itemCount: items.length }, 'Dados de alimentação obtidos')
+
+    await updateFoodSpending(foodSpending)
+
+    const valorFormatado = formatBRL(total_cents)
+    const nomeMes = MESES[month - 1] ?? `mês ${month}`
+
+    const itemLines = items
+      .map(i => `- ${i.description} (${i.date}): ${formatBRL(Math.abs(i.amount_cents))}`)
+      .join('\n')
+
+    sendEmail({
+      to: ADMIN_EMAIL,
+      subject: `Gastos com alimentação de ${nomeMes}/${year} atualizados`,
+      body: `O gasto com alimentação referente a ${nomeMes}/${year} foi atualizado.\n\nTotal: ${valorFormatado}\n\nItens:\n${itemLines}`,
+    })
+    log.info({ to: ADMIN_EMAIL, valorFormatado, nomeMes, year }, 'E-mail de alimentação enviado')
+
+    await message.reply(
+      `Gastos com alimentação atualizados!\nPeríodo: ${nomeMes}/${year}\nTotal: ${valorFormatado}\nItens: ${items.length}\nE-mail de notificação enviado para ${ADMIN_EMAIL}.`,
+    )
+  }
+
+  protected getUsage() { return '`$food-spending`' }
+}

--- a/src/discord/commands/admin/index.ts
+++ b/src/discord/commands/admin/index.ts
@@ -4,6 +4,7 @@ import { RestartCommand } from './RestartCommand'
 import { DbCleanCommand } from './DbCleanCommand'
 import { MeConecteiCommand } from './MeConecteiCommand'
 import { UpdateInterestCommand } from './UpdateInterestCommand'
+import { FoodSpendingCommand } from './FoodSpendingCommand'
 
 const auth = new ConfigAuthorizationService(process.env.ADMIN_DISCORD_USER_IDS ?? '')
 const adminGuard = new AdminGuard(auth)
@@ -12,8 +13,10 @@ const restartCommand = adminGuard.protect(new RestartCommand())
 const dbCleanCommand = adminGuard.protect(new DbCleanCommand())
 const meConecteiCommand = adminGuard.protect(new MeConecteiCommand())
 const updateInterestCommand = adminGuard.protect(new UpdateInterestCommand())
+const foodSpendingCommand = adminGuard.protect(new FoodSpendingCommand())
 
 export const restartHandler = restartCommand.asNoArgsHandler()
 export const dbCleanHandler = dbCleanCommand.asNoArgsHandler()
 export const meconecteiHandler = meConecteiCommand.asHandler()
 export const updateInterestHandler = updateInterestCommand.asNoArgsHandler()
+export const foodSpendingHandler = foodSpendingCommand.asNoArgsHandler()

--- a/src/services/finance/OrganizzeService.ts
+++ b/src/services/finance/OrganizzeService.ts
@@ -82,3 +82,37 @@ export async function updateInterest(interest: Interest): Promise<unknown> {
     return data
   } catch (err) { handleError(err) }
 }
+
+export interface FoodSpendingItem {
+  id: number
+  description: string
+  date: string
+  amount_cents: number
+  category_id: number
+}
+
+export interface FoodSpending {
+  total_cents: number
+  total_brl: number
+  year: number
+  month: number
+  items: FoodSpendingItem[]
+}
+
+export async function getFoodSpending(): Promise<FoodSpending> {
+  try {
+    const { data } = await apiCall.get<FoodSpending>('/food-spending')
+    return data
+  } catch (err) { handleError(err) }
+}
+
+export async function updateFoodSpending(foodSpending: FoodSpending): Promise<unknown> {
+  try {
+    const { data } = await apiCall.post('/food-spending', {
+      amount_cents: foodSpending.total_cents,
+      year: foodSpending.year,
+      month: foodSpending.month,
+    })
+    return data
+  } catch (err) { handleError(err) }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `$food-spending` command (admin only), seguindo o mesmo padrão do `$atualizar-juros`
- Faz `GET /food-spending` para buscar os gastos do mês com alimentação
- Faz `POST /food-spending` com `{ amount_cents, year, month }` para persistir o total
- Envia e-mail ao admin com o total formatado e a lista detalhada de itens

## Arquivos alterados

- `src/services/finance/OrganizzeService.ts` — novas interfaces `FoodSpendingItem` / `FoodSpending` e funções `getFoodSpending` / `updateFoodSpending`
- `src/discord/commands/admin/FoodSpendingCommand.ts` — novo comando
- `src/discord/commands/admin/index.ts` — exporta `foodSpendingHandler` com guard de admin
- `src/commands/lista-comandos.ts` — registra o comando `food-spending`

## Test plan

- [ ] Executar `$food-spending` como admin → deve buscar dados, atualizar e enviar e-mail
- [ ] Executar `$food-spending` como usuário não-admin → deve retornar "Você não tem permissão"

https://claude.ai/code/session_01L6cY75Pysqg2miuAoX9EbF
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6cY75Pysqg2miuAoX9EbF)_