### PR TITLE
feat: add USD expense conversion for spent money and batch commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,8 +59,6 @@
         "jest": "^30.3.0",
         "nodemon": "^3.0.1",
         "ts-jest": "^29.4.6",
-        "ts-node": "^10.9.2",
-        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -781,7 +779,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1341,6 +1338,8 @@
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1354,6 +1353,8 @@
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1433,7 +1434,6 @@
       "integrity": "sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discordjs/node-pre-gyp": "^0.4.5",
         "node-addon-api": "^8.1.0"
@@ -1664,6 +1664,7 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1680,6 +1681,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1702,6 +1704,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1724,6 +1727,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1740,6 +1744,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1756,6 +1761,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1772,6 +1778,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1788,6 +1795,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1804,6 +1812,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1820,6 +1829,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1836,6 +1846,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1852,6 +1863,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1868,6 +1880,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1884,6 +1897,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1906,6 +1920,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1928,6 +1943,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1950,6 +1966,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1972,6 +1989,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1994,6 +2012,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2016,6 +2035,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2038,6 +2058,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2057,6 +2078,7 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -2079,6 +2101,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2098,6 +2121,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2117,6 +2141,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3306,7 +3331,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -4473,28 +4497,36 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -4770,7 +4802,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -5318,6 +5349,8 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5331,6 +5364,8 @@
       "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -5454,7 +5489,9 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5558,7 +5595,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
       "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -5918,7 +5954,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6047,7 +6082,6 @@
       "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -6480,7 +6514,9 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6752,8 +6788,7 @@
       "version": "0.0.1367902",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
       "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dfa": {
       "version": "1.2.0",
@@ -6767,6 +6802,8 @@
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -7438,7 +7475,6 @@
       "integrity": "sha512-gyGTIf5kgmLDmH7Rwj8vMmNK46bjXKKofHS2gY+LUqoTe/iybVuTuvnhJQR2tZHlKlDG7A/BIH7cRa2jWDKgWw==",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
-      "peer": true,
       "dependencies": {
         "@derhuerst/http-basic": "^8.2.0",
         "env-paths": "^2.2.0",
@@ -8000,7 +8036,6 @@
       "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -8849,7 +8884,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -10399,7 +10433,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -13555,6 +13588,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -13592,31 +13626,6 @@
         "@swc/wasm": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^2.2.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/tslib": {
@@ -13687,7 +13696,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13868,7 +13876,6 @@
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -13900,7 +13907,9 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -14281,6 +14290,8 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -14320,7 +14331,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/services/finance/CurrencyService.ts
+++ b/src/services/finance/CurrencyService.ts
@@ -1,0 +1,11 @@
+import axios from 'axios'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('CurrencyService')
+
+export async function fetchUsdToBrlRate(): Promise<number> {
+    const response = await axios.get('https://economia.awesomeapi.com.br/json/last/USD-BRL')
+    const rate = parseFloat(response.data.USDBRL.bid)
+    log.debug({ rate }, 'USD to BRL rate fetched')
+    return rate
+}

--- a/src/services/finance/CurrencyService.ts
+++ b/src/services/finance/CurrencyService.ts
@@ -9,3 +9,18 @@ export async function fetchUsdToBrlRate(): Promise<number> {
     log.debug({ rate }, 'USD to BRL rate fetched')
     return rate
 }
+
+export async function resolveMoneyToBrl(rawMoney: string): Promise<{ brlValue: number; conversionInfo?: string }> {
+    const isUsd = rawMoney.toLowerCase().includes('usd')
+    if (!isUsd) {
+        return { brlValue: Number(rawMoney.trim()) }
+    }
+    const usdValue = Number(rawMoney.toLowerCase().replace('usd', '').trim())
+    if (isNaN(usdValue)) {
+        return { brlValue: NaN }
+    }
+    const rate = await fetchUsdToBrlRate()
+    const brlValue = parseFloat((usdValue * rate).toFixed(2))
+    const conversionInfo = `USD ${usdValue.toFixed(2)} → R$ ${brlValue.toFixed(2)} (cotação: R$ ${rate.toFixed(2)})`
+    return { brlValue, conversionInfo }
+}

--- a/src/telegram/handlers/DailyBudgetHandler.ts
+++ b/src/telegram/handlers/DailyBudgetHandler.ts
@@ -6,6 +6,7 @@ import {
   getMyDailyBudget,
   spentMoney,
 } from '../../services/finance/DailyBudgetService'
+import { fetchUsdToBrlRate } from '../../services/finance/CurrencyService'
 import { KEYBOARDS } from '../TelegramConfig'
 import { createLogger } from '../../shared/logger/Logger'
 
@@ -17,7 +18,22 @@ const state = {
   batchInserts: [] as { money: string; description: string }[],
 }
 
-function handleBatchResponse(ctx: Context, content: [string, string]) {
+async function resolveMoneyToBrl(rawMoney: string): Promise<{ brlValue: number; conversionInfo?: string }> {
+  const isUsd = rawMoney.toLowerCase().includes('usd')
+  if (!isUsd) {
+    return { brlValue: Number(rawMoney.trim()) }
+  }
+  const usdValue = Number(rawMoney.toLowerCase().replace('usd', '').trim())
+  if (isNaN(usdValue)) {
+    return { brlValue: NaN }
+  }
+  const rate = await fetchUsdToBrlRate()
+  const brlValue = parseFloat((usdValue * rate).toFixed(2))
+  const conversionInfo = `USD ${usdValue.toFixed(2)} → R$ ${brlValue.toFixed(2)} (cotação: R$ ${rate.toFixed(2)})`
+  return { brlValue, conversionInfo }
+}
+
+async function handleBatchResponse(ctx: Context, content: [string, string]) {
   if (content[0]?.toLowerCase() === 'fim') {
     state.awaitResponseSpentMoney = false
     state.batchResponse = false
@@ -28,8 +44,19 @@ function handleBatchResponse(ctx: Context, content: [string, string]) {
     state.batchInserts = []
     return
   }
+  try {
+    const { brlValue, conversionInfo } = await resolveMoneyToBrl(content[0] ?? '')
+    const moneyStr = String(brlValue)
+    state.batchInserts.push({ money: moneyStr, description: content[1] ?? '' })
+    if (conversionInfo) {
+      ctx.reply(`Conversão: ${conversionInfo}`)
+    }
+  } catch (err) {
+    log.error({ err }, 'Error resolving USD in batch')
+    ctx.reply('Erro ao buscar cotação do dólar. Tente novamente.')
+    return
+  }
   ctx.reply('digite fim para finalizar o batch, ou continue informando o valor e descricao separado por virgula')
-  state.batchInserts.push({ money: content[0] ?? '', description: content[1] ?? '' })
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -68,10 +95,14 @@ export function registerDailyBudgetHandlers(bot: any): void {
   bot.on(message('text'), async (ctx: Context) => {
     if (!state.awaitResponseSpentMoney) return
     const text = (ctx.update as never as { message: { text: string } }).message.text
-    const [money, description] = text.split(',') as [string, string]
-    if (state.batchResponse) { handleBatchResponse(ctx, [money, description]); return }
+    const [rawMoney, description] = text.split(',') as [string, string]
+    if (state.batchResponse) { await handleBatchResponse(ctx, [rawMoney, description]); return }
     try {
-      const budget = await spentMoney({ money, description })
+      const { brlValue, conversionInfo } = await resolveMoneyToBrl(rawMoney ?? '')
+      if (conversionInfo) {
+        await ctx.reply(`Conversão: ${conversionInfo}`)
+      }
+      const budget = await spentMoney({ money: brlValue, description })
       ctx.reply(`your new daily budget is R$ ${budget}`)
     } catch (err) {
       log.error({ err }, 'Error processing spent money')

--- a/src/telegram/handlers/DailyBudgetHandler.ts
+++ b/src/telegram/handlers/DailyBudgetHandler.ts
@@ -6,7 +6,7 @@ import {
   getMyDailyBudget,
   spentMoney,
 } from '../../services/finance/DailyBudgetService'
-import { fetchUsdToBrlRate } from '../../services/finance/CurrencyService'
+import { resolveMoneyToBrl } from '../../services/finance/CurrencyService'
 import { KEYBOARDS } from '../TelegramConfig'
 import { createLogger } from '../../shared/logger/Logger'
 
@@ -18,20 +18,6 @@ const state = {
   batchInserts: [] as { money: string; description: string }[],
 }
 
-async function resolveMoneyToBrl(rawMoney: string): Promise<{ brlValue: number; conversionInfo?: string }> {
-  const isUsd = rawMoney.toLowerCase().includes('usd')
-  if (!isUsd) {
-    return { brlValue: Number(rawMoney.trim()) }
-  }
-  const usdValue = Number(rawMoney.toLowerCase().replace('usd', '').trim())
-  if (isNaN(usdValue)) {
-    return { brlValue: NaN }
-  }
-  const rate = await fetchUsdToBrlRate()
-  const brlValue = parseFloat((usdValue * rate).toFixed(2))
-  const conversionInfo = `USD ${usdValue.toFixed(2)} → R$ ${brlValue.toFixed(2)} (cotação: R$ ${rate.toFixed(2)})`
-  return { brlValue, conversionInfo }
-}
 
 async function handleBatchResponse(ctx: Context, content: [string, string]) {
   if (content[0]?.toLowerCase() === 'fim') {

--- a/tests/unit/services/finance/CurrencyService.test.ts
+++ b/tests/unit/services/finance/CurrencyService.test.ts
@@ -1,0 +1,67 @@
+import axios from 'axios'
+import { fetchUsdToBrlRate, resolveMoneyToBrl } from '../../../../src/services/finance/CurrencyService'
+
+jest.mock('axios')
+jest.mock('../../../../src/shared/logger/Logger', () => ({
+  createLogger: () => ({ debug: jest.fn(), error: jest.fn() }),
+}))
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+describe('fetchUsdToBrlRate', () => {
+  it('retorna a cotação do dólar corretamente', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { USDBRL: { bid: '5.50' } } })
+
+    const rate = await fetchUsdToBrlRate()
+
+    expect(rate).toBe(5.5)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://economia.awesomeapi.com.br/json/last/USD-BRL'
+    )
+  })
+
+  it('propaga o erro quando a API falha', async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error('network error'))
+
+    await expect(fetchUsdToBrlRate()).rejects.toThrow('network error')
+  })
+})
+
+describe('resolveMoneyToBrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('retorna o valor em BRL sem chamar a API quando não há usd', async () => {
+    const result = await resolveMoneyToBrl('23.55')
+
+    expect(result.brlValue).toBe(23.55)
+    expect(result.conversionInfo).toBeUndefined()
+    expect(mockedAxios.get).not.toHaveBeenCalled()
+  })
+
+  it('converte valor USD para BRL buscando a cotação online', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { USDBRL: { bid: '5.50' } } })
+
+    const result = await resolveMoneyToBrl('23.44usd')
+
+    expect(result.brlValue).toBe(128.92)
+    expect(result.conversionInfo).toBe('USD 23.44 → R$ 128.92 (cotação: R$ 5.50)')
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('aceita usd em maiúsculas', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { USDBRL: { bid: '5.00' } } })
+
+    const result = await resolveMoneyToBrl('10USD')
+
+    expect(result.brlValue).toBe(50)
+    expect(result.conversionInfo).toContain('USD 10.00 → R$ 50.00')
+  })
+
+  it('propaga o erro da API para o chamador tratar', async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error('timeout'))
+
+    await expect(resolveMoneyToBrl('10usd')).rejects.toThrow('timeout')
+  })
+})


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Novo formato aceito: `23.44usd, despesa em dólar` (além do formato existente `23.55, restaurante`)
- Quando o campo valor contém `usd`, busca a cotação em tempo real via [AwesomeAPI](https://economia.awesomeapi.com.br/json/last/USD-BRL), converte para BRL e registra o gasto convertido
- Informa ao usuário a conversão realizada antes de confirmar o novo saldo (ex: `Conversão: USD 23.44 → R$ 128.92 (cotação: R$ 5.50)`)
- Funciona tanto no comando **spent money** quanto no modo **batch**

## Arquivos alterados

- `src/services/finance/CurrencyService.ts` — novo serviço que faz o fetch da cotação USD/BRL
- `src/telegram/handlers/DailyBudgetHandler.ts` — lógica de parsing atualizada com suporte a `usd`, `handleBatchResponse` tornado async

## Test plan

- [ ] Enviar `23.44usd, restaurante` no comando spent money → deve mostrar mensagem de conversão e novo saldo em BRL
- [ ] Enviar `50, supermercado` (sem usd) → comportamento inalterado
- [ ] No modo batch, misturar itens com e sem `usd` → cada item USD exibe conversão, saldo final correto
- [ ] Simular falha na API de cotação → deve responder com mensagem de erro amigável

https://claude.ai/code/session_016vZAS42zDLcrRHiuRkAjRQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016vZAS42zDLcrRHiuRkAjRQ)_