### PR TITLE
fix: cache USD/BRL rate to avoid 429, guard batchInsert against empty…

### DIFF
--- a/src/services/finance/CurrencyService.ts
+++ b/src/services/finance/CurrencyService.ts
@@ -3,9 +3,21 @@ import { createLogger } from '../../shared/logger/Logger'
 
 const log = createLogger('CurrencyService')
 
+const CACHE_TTL_MS = 10 * 60 * 1000 // 10 minutes
+let rateCache: { rate: number; expiresAt: number } | null = null
+
+export function clearRateCache(): void {
+    rateCache = null
+}
+
 export async function fetchUsdToBrlRate(): Promise<number> {
+    if (rateCache && Date.now() < rateCache.expiresAt) {
+        log.debug({ rate: rateCache.rate }, 'USD to BRL rate from cache')
+        return rateCache.rate
+    }
     const response = await axios.get('https://economia.awesomeapi.com.br/json/last/USD-BRL')
     const rate = parseFloat(response.data.USDBRL.bid)
+    rateCache = { rate, expiresAt: Date.now() + CACHE_TTL_MS }
     log.debug({ rate }, 'USD to BRL rate fetched')
     return rate
 }

--- a/src/services/finance/DailyBudgetService.ts
+++ b/src/services/finance/DailyBudgetService.ts
@@ -480,6 +480,10 @@ export function batchInsert(
             description: i.description
         }))
 
+    if (itemsMapped.length === 0) {
+        return state.budget!
+    }
+
     itemsMapped.forEach(({ money, description }) =>
         state.transactions.push({ money, description })
     )

--- a/tests/unit/services/finance/CurrencyService.test.ts
+++ b/tests/unit/services/finance/CurrencyService.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { fetchUsdToBrlRate, resolveMoneyToBrl } from '../../../../src/services/finance/CurrencyService'
+import { clearRateCache, fetchUsdToBrlRate, resolveMoneyToBrl } from '../../../../src/services/finance/CurrencyService'
 
 jest.mock('axios')
 jest.mock('../../../../src/shared/logger/Logger', () => ({
@@ -7,6 +7,11 @@ jest.mock('../../../../src/shared/logger/Logger', () => ({
 }))
 
 const mockedAxios = axios as jest.Mocked<typeof axios>
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  clearRateCache()
+})
 
 describe('fetchUsdToBrlRate', () => {
   it('retorna a cotação do dólar corretamente', async () => {
@@ -20,6 +25,16 @@ describe('fetchUsdToBrlRate', () => {
     )
   })
 
+  it('usa cache na segunda chamada sem bater na API', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { USDBRL: { bid: '5.50' } } })
+
+    await fetchUsdToBrlRate()
+    const rate = await fetchUsdToBrlRate()
+
+    expect(rate).toBe(5.5)
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+  })
+
   it('propaga o erro quando a API falha', async () => {
     mockedAxios.get.mockRejectedValueOnce(new Error('network error'))
 
@@ -28,10 +43,6 @@ describe('fetchUsdToBrlRate', () => {
 })
 
 describe('resolveMoneyToBrl', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
   it('retorna o valor em BRL sem chamar a API quando não há usd', async () => {
     const result = await resolveMoneyToBrl('23.55')
 
@@ -47,6 +58,16 @@ describe('resolveMoneyToBrl', () => {
 
     expect(result.brlValue).toBe(128.92)
     expect(result.conversionInfo).toBe('USD 23.44 → R$ 128.92 (cotação: R$ 5.50)')
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('múltiplas conversões USD reutilizam o cache — API chamada apenas uma vez', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { USDBRL: { bid: '5.50' } } })
+
+    await resolveMoneyToBrl('10usd')
+    await resolveMoneyToBrl('20usd')
+    await resolveMoneyToBrl('30usd')
+
     expect(mockedAxios.get).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
… array

- CurrencyService: cache the exchange rate for 10 minutes so multiple USD items in a batch share one API call instead of hammering the endpoint
- DailyBudgetService: early-return in batchInsert when itemsMapped is empty to prevent MongoInvalidArgumentError from insertMany([])
- Tests: reset cache between test cases via clearRateCache; add cache-hit and multi-item-batch scenarios

https://claude.ai/code/session_016vZAS42zDLcrRHiuRkAjRQ