### PR TITLE
fix: switch USD/BRL rate API to arbitragem-crypto.cloud

### DIFF
--- a/src/services/finance/CurrencyService.ts
+++ b/src/services/finance/CurrencyService.ts
@@ -15,8 +15,15 @@ export async function fetchUsdToBrlRate(): Promise<number> {
         log.debug({ rate: rateCache.rate }, 'USD to BRL rate from cache')
         return rateCache.rate
     }
-    const response = await axios.get('https://economia.awesomeapi.com.br/json/last/USD-BRL')
-    const rate = parseFloat(response.data.USDBRL.bid)
+    const response = await axios.get('https://api.arbitragem-crypto.cloud/v1/dollar', {
+        timeout: 25000,
+        headers: {
+            'accept': 'application/json, text/plain, */*',
+            'origin': 'https://arbitragem-crypto.cloud',
+            'referer': 'https://arbitragem-crypto.cloud/',
+        },
+    })
+    const rate = parseFloat(response.data.usd)
     rateCache = { rate, expiresAt: Date.now() + CACHE_TTL_MS }
     log.debug({ rate }, 'USD to BRL rate fetched')
     return rate

--- a/tests/unit/services/finance/CurrencyService.test.ts
+++ b/tests/unit/services/finance/CurrencyService.test.ts
@@ -15,18 +15,19 @@ beforeEach(() => {
 
 describe('fetchUsdToBrlRate', () => {
   it('retorna a cotação do dólar corretamente', async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: { USDBRL: { bid: '5.50' } } })
+    mockedAxios.get.mockResolvedValueOnce({ data: { usd: 5.50 } })
 
     const rate = await fetchUsdToBrlRate()
 
     expect(rate).toBe(5.5)
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      'https://economia.awesomeapi.com.br/json/last/USD-BRL'
+      'https://api.arbitragem-crypto.cloud/v1/dollar',
+      expect.objectContaining({ timeout: 25000 })
     )
   })
 
   it('usa cache na segunda chamada sem bater na API', async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: { USDBRL: { bid: '5.50' } } })
+    mockedAxios.get.mockResolvedValueOnce({ data: { usd: 5.50 } })
 
     await fetchUsdToBrlRate()
     const rate = await fetchUsdToBrlRate()
@@ -52,7 +53,7 @@ describe('resolveMoneyToBrl', () => {
   })
 
   it('converte valor USD para BRL buscando a cotação online', async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: { USDBRL: { bid: '5.50' } } })
+    mockedAxios.get.mockResolvedValueOnce({ data: { usd: 5.50 } })
 
     const result = await resolveMoneyToBrl('23.44usd')
 
@@ -62,7 +63,7 @@ describe('resolveMoneyToBrl', () => {
   })
 
   it('múltiplas conversões USD reutilizam o cache — API chamada apenas uma vez', async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: { USDBRL: { bid: '5.50' } } })
+    mockedAxios.get.mockResolvedValueOnce({ data: { usd: 5.50 } })
 
     await resolveMoneyToBrl('10usd')
     await resolveMoneyToBrl('20usd')
@@ -72,7 +73,7 @@ describe('resolveMoneyToBrl', () => {
   })
 
   it('aceita usd em maiúsculas', async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: { USDBRL: { bid: '5.00' } } })
+    mockedAxios.get.mockResolvedValueOnce({ data: { usd: 5.00 } })
 
     const result = await resolveMoneyToBrl('10USD')
 


### PR DESCRIPTION
AwesomeAPI was returning 429. New endpoint returns {"usd": 4.9094} with a 25s timeout and proper origin/referer headers.

https://claude.ai/code/session_016vZAS42zDLcrRHiuRkAjRQ