### PR TITLE
feat: Telegram photo handler for bank notification images (dailyBudget)

### DIFF
--- a/src/services/finance/BankNotificationImageService.ts
+++ b/src/services/finance/BankNotificationImageService.ts
@@ -9,7 +9,8 @@ const log = createLogger('BankNotificationImageService')
 const transactionSchema = z.object({
   transactions: z.array(
     z.object({
-      money: z.number().describe('Valor da transação em BRL como número decimal (ex: 45.86)'),
+      money: z.number().describe('Valor numérico da transação sem símbolo de moeda (ex: 45.86)'),
+      currency: z.enum(['BRL', 'USD']).describe('Moeda da transação: BRL para reais, USD para dólares'),
       description: z.string().describe('Nome do estabelecimento ou descrição da transação'),
     })
   ).describe('Lista de transações bancárias encontradas na imagem'),
@@ -18,17 +19,20 @@ const transactionSchema = z.object({
 })
 
 export type BankNotificationResult = z.infer<typeof transactionSchema>
+export type ExtractedTransaction = BankNotificationResult['transactions'][number]
 
-const PROMPT = `Você é um agente especialista em extrair dados de notificações bancárias brasileiras.
+const PROMPT = `Você é um agente especialista em extrair dados de notificações bancárias.
 Analise a imagem e extraia TODAS as notificações de transações bancárias visíveis.
 
 Para cada transação extraia:
-- money: valor em BRL como número decimal (ex: 45.86 — sem R$, sem vírgula)
+- money: valor numérico sem símbolo de moeda (ex: 45.86 — use ponto decimal, sem R$ ou $)
+- currency: "BRL" se for em reais, "USD" se for em dólares americanos
 - description: nome do estabelecimento/loja
 
-A imagem pode conter uma ou mais notificações. Exemplos de padrões comuns:
-"Compra de R$ 45,86 APROVADA em SQ *BAREBOTTLE - SALES para o cartão com final 4545"
-"Débito de R$ 120,00 em SUPERMERCADO XYZ"
+A imagem pode conter uma ou mais notificações. Exemplos:
+"Compra de R$ 45,86 APROVADA em SQ *BAREBOTTLE - SALES" → money: 45.86, currency: "BRL"
+"Purchase of USD 12.50 at AMAZON" → money: 12.50, currency: "USD"
+"Débito de R$ 120,00 em SUPERMERCADO XYZ" → money: 120.00, currency: "BRL"
 
 Se a imagem não contiver nenhuma notificação bancária identificável, retorne success: false e descreva o motivo em reason.`
 

--- a/src/services/finance/BankNotificationImageService.ts
+++ b/src/services/finance/BankNotificationImageService.ts
@@ -15,7 +15,7 @@ const transactionSchema = z.object({
     })
   ).describe('Lista de transações bancárias encontradas na imagem'),
   success: z.boolean().describe('true se ao menos uma transação foi identificada com sucesso'),
-  reason: z.string().optional().describe('Motivo de falha quando success for false'),
+  reason: z.string().nullable().describe('Motivo de falha quando success for false, null caso contrário'),
 })
 
 export type BankNotificationResult = z.infer<typeof transactionSchema>

--- a/src/services/finance/BankNotificationImageService.ts
+++ b/src/services/finance/BankNotificationImageService.ts
@@ -1,0 +1,74 @@
+import { ChatOpenAI } from '@langchain/openai'
+import { HumanMessage } from '@langchain/core/messages'
+import { z } from 'zod'
+import { env } from '../../config/env'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('BankNotificationImageService')
+
+const transactionSchema = z.object({
+  transactions: z.array(
+    z.object({
+      money: z.number().describe('Valor da transação em BRL como número decimal (ex: 45.86)'),
+      description: z.string().describe('Nome do estabelecimento ou descrição da transação'),
+    })
+  ).describe('Lista de transações bancárias encontradas na imagem'),
+  success: z.boolean().describe('true se ao menos uma transação foi identificada com sucesso'),
+  reason: z.string().optional().describe('Motivo de falha quando success for false'),
+})
+
+export type BankNotificationResult = z.infer<typeof transactionSchema>
+
+const PROMPT = `Você é um agente especialista em extrair dados de notificações bancárias brasileiras.
+Analise a imagem e extraia TODAS as notificações de transações bancárias visíveis.
+
+Para cada transação extraia:
+- money: valor em BRL como número decimal (ex: 45.86 — sem R$, sem vírgula)
+- description: nome do estabelecimento/loja
+
+A imagem pode conter uma ou mais notificações. Exemplos de padrões comuns:
+"Compra de R$ 45,86 APROVADA em SQ *BAREBOTTLE - SALES para o cartão com final 4545"
+"Débito de R$ 120,00 em SUPERMERCADO XYZ"
+
+Se a imagem não contiver nenhuma notificação bancária identificável, retorne success: false e descreva o motivo em reason.`
+
+export async function extractTransactionsFromImage(imageUrl: string): Promise<BankNotificationResult> {
+  if (!env.KEY_OPEN_AI) {
+    return { transactions: [], success: false, reason: 'Chave da OpenAI não configurada' }
+  }
+
+  const model = new ChatOpenAI({
+    modelName: 'gpt-4o',
+    temperature: 0,
+    apiKey: env.KEY_OPEN_AI,
+  })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const structuredModel = (model as any).withStructuredOutput(transactionSchema)
+
+  const message = new HumanMessage({
+    content: [
+      {
+        type: 'image_url',
+        image_url: { url: imageUrl },
+      },
+      {
+        type: 'text',
+        text: PROMPT,
+      },
+    ],
+  })
+
+  try {
+    const result = await structuredModel.invoke([message])
+    log.info({ result }, 'Transactions extracted from bank notification image')
+    return result as BankNotificationResult
+  } catch (err) {
+    log.error({ err }, 'Error extracting transactions from bank notification image')
+    return {
+      transactions: [],
+      success: false,
+      reason: `Erro ao processar a imagem: ${(err as Error).message}`,
+    }
+  }
+}

--- a/src/telegram/handlers/DailyBudgetHandler.ts
+++ b/src/telegram/handlers/DailyBudgetHandler.ts
@@ -7,6 +7,7 @@ import {
   spentMoney,
 } from '../../services/finance/DailyBudgetService'
 import { resolveMoneyToBrl } from '../../services/finance/CurrencyService'
+import { extractTransactionsFromImage } from '../../services/finance/BankNotificationImageService'
 import { KEYBOARDS } from '../TelegramConfig'
 import { createLogger } from '../../shared/logger/Logger'
 
@@ -95,6 +96,35 @@ export function registerDailyBudgetHandlers(bot: any): void {
       ctx.reply('An error occurred. Please try again.')
     } finally {
       state.awaitResponseSpentMoney = false
+    }
+  })
+
+  bot.on(message('photo'), async (ctx: Context) => {
+    const photos = (ctx.update as never as { message: { photo: Array<{ file_id: string }> } }).message.photo
+    const largestPhoto = photos[photos.length - 1]
+    if (!largestPhoto) {
+      await ctx.reply('Não foi possível obter a imagem.')
+      return
+    }
+
+    await ctx.reply('Analisando notificação bancária...')
+
+    try {
+      const fileLink = await ctx.telegram.getFileLink(largestPhoto.file_id)
+      const result = await extractTransactionsFromImage(fileLink.href)
+
+      if (!result.success || result.transactions.length === 0) {
+        await ctx.reply(`Não consegui identificar transações bancárias na imagem.${result.reason ? ` ${result.reason}` : ''}`)
+        return
+      }
+
+      const newBudget = batchInsert(result.transactions)
+      const summary = result.transactions.map((t: { money: number; description: string }) => `- R$ ${t.money.toFixed(2)}: ${t.description}`).join('\n')
+      await ctx.reply(`Transações registradas:\n${summary}`)
+      await ctx.reply(`Seu novo saldo diário é R$ ${newBudget.toFixed(2)}`)
+    } catch (err) {
+      log.error({ err }, 'Error processing bank notification image')
+      await ctx.reply('Ocorreu um erro ao processar a imagem. Tente novamente.')
     }
   })
 }

--- a/src/telegram/handlers/DailyBudgetHandler.ts
+++ b/src/telegram/handlers/DailyBudgetHandler.ts
@@ -7,7 +7,7 @@ import {
   spentMoney,
 } from '../../services/finance/DailyBudgetService'
 import { resolveMoneyToBrl } from '../../services/finance/CurrencyService'
-import { extractTransactionsFromImage } from '../../services/finance/BankNotificationImageService'
+import { extractTransactionsFromImage, type ExtractedTransaction } from '../../services/finance/BankNotificationImageService'
 import { KEYBOARDS } from '../TelegramConfig'
 import { createLogger } from '../../shared/logger/Logger'
 
@@ -118,8 +118,22 @@ export function registerDailyBudgetHandlers(bot: any): void {
         return
       }
 
-      const newBudget = batchInsert(result.transactions)
-      const summary = result.transactions.map((t: { money: number; description: string }) => `- R$ ${t.money.toFixed(2)}: ${t.description}`).join('\n')
+      const conversionLines: string[] = []
+      const resolved = await Promise.all(
+        result.transactions.map(async (t: ExtractedTransaction) => {
+          const rawMoney = t.currency === 'USD' ? `${t.money} usd` : String(t.money)
+          const { brlValue, conversionInfo } = await resolveMoneyToBrl(rawMoney)
+          if (conversionInfo) conversionLines.push(conversionInfo)
+          return { money: brlValue, description: t.description }
+        })
+      )
+
+      if (conversionLines.length > 0) {
+        await ctx.reply(`Conversões:\n${conversionLines.join('\n')}`)
+      }
+
+      const newBudget = batchInsert(resolved)
+      const summary = resolved.map((t: { money: number; description: string }) => `- R$ ${t.money.toFixed(2)}: ${t.description}`).join('\n')
       await ctx.reply(`Transações registradas:\n${summary}`)
       await ctx.reply(`Seu novo saldo diário é R$ ${newBudget.toFixed(2)}`)
     } catch (err) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `BankNotificationImageService.ts` — LangChain agent using GPT-4o vision to extract bank transaction notifications from images
- Updates `DailyBudgetHandler.ts` — new Telegram `message('photo')` handler that receives the image, calls the agent, and feeds results into `batchInsert`
- Supports **one or more notifications per image**
- If the agent cannot identify any transaction, it replies to the user with the reason and does nothing else

## How it works

1. User sends a screenshot of bank notification(s) to the authorized Telegram bot
2. Bot downloads the highest-resolution version of the photo
3. GPT-4o extracts all transactions (amount in BRL + establishment name) via structured output
4. If successful → `batchInsert` is called and a summary + new balance are sent back
5. If unsuccessful → user receives a clear failure message, no data is modified

## Test plan

- [ ] Send a single Nubank-style notification screenshot → bot registers one transaction
- [ ] Send a screenshot with multiple notifications → bot registers all transactions in a single batch
- [ ] Send an unrelated image (no bank notification) → bot replies with failure message, no budget change
- [ ] Verify `getMyDailyBudget` reflects the new balance after each successful import

https://claude.ai/code/session_013P18Zjg63yJG21fqg4Wc7w
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013P18Zjg63yJG21fqg4Wc7w)_