### PR TITLE
fix: corrige campo de conteúdo do email (body → message)

### DIFF
--- a/src/discord/commands/admin/FoodSpendingCommand.ts
+++ b/src/discord/commands/admin/FoodSpendingCommand.ts
@@ -45,7 +45,7 @@ export class FoodSpendingCommand extends BaseCommand<typeof schema> {
     sendEmail({
       to: ADMIN_EMAIL,
       subject: `Gastos com alimentação de ${nomeMes}/${year} atualizados`,
-      body: `O gasto com alimentação referente a ${nomeMes}/${year} foi atualizado.\n\nTotal: ${valorFormatado}\n\nItens:\n${itemLines}`,
+      message: `O gasto com alimentação referente a ${nomeMes}/${year} foi atualizado.\n\nTotal: ${valorFormatado}\n\nItens:\n${itemLines}`,
     })
     log.info({ to: ADMIN_EMAIL, valorFormatado, nomeMes, year }, 'E-mail de alimentação enviado')
 

--- a/src/discord/commands/admin/MeConecteiCommand.ts
+++ b/src/discord/commands/admin/MeConecteiCommand.ts
@@ -28,7 +28,7 @@ export class MeConecteiCommand extends BaseCommand<typeof schema> {
     sendEmail({
       to: email,
       subject: 'Conta criada no me-conectei',
-      body: `Sua conta foi criada.\nEmail: ${email}\nSenha: ${password}\n\nAlgere sua senha após o primeiro login.`,
+      message: `Sua conta foi criada.\nEmail: ${email}\nSenha: ${password}\n\nAlgere sua senha após o primeiro login.`,
     })
 
     log.info({ email }, 'Conta Me Conectei criada')

--- a/src/discord/commands/admin/UpdateInterestCommand.ts
+++ b/src/discord/commands/admin/UpdateInterestCommand.ts
@@ -57,7 +57,7 @@ export class UpdateInterestCommand extends BaseCommand<typeof schema> {
     sendEmail({
       to: ADMIN_EMAIL,
       subject: `Juros de ${nomeMes}/${year} atualizados`,
-      body: [
+      message: [
         `O gasto de juros referente a ${nomeMes}/${year} foi atualizado.`,
         ``,
         `Valor total de juros: ${valorFormatado}`,

--- a/src/discord/commands/finance/BudgetReportCommand.ts
+++ b/src/discord/commands/finance/BudgetReportCommand.ts
@@ -52,7 +52,7 @@ export class BudgetReportCommand extends BaseCommand<typeof schema> {
       sendEmail({
         to: ADMIN_EMAIL,
         subject: 'Relatorio de despesas',
-        body: 'Segue em anexo',
+        message: 'Segue em anexo',
         attachmentLink: url,
       })
     }

--- a/src/services/b3/CryptoArbitrageService.ts
+++ b/src/services/b3/CryptoArbitrageService.ts
@@ -304,7 +304,7 @@ export function processAMQPMessage(message: any, routingKey: string): void {
             sendEmail({
                 to: email,
                 subject: 'Alerta de arbitragem',
-                body: emailMessage
+                message: emailMessage
             })
             break
         }

--- a/src/services/email/EmailService.ts
+++ b/src/services/email/EmailService.ts
@@ -9,7 +9,7 @@ const EMAIL_URL = `${COMMUNICATION_SERVER_URL}/email`
 export interface EmailPayload {
   to: string
   subject: string
-  body: string
+  message: string
   [key: string]: unknown
 }
 

--- a/src/services/finance/CaixinhaService.ts
+++ b/src/services/finance/CaixinhaService.ts
@@ -102,7 +102,7 @@ function enviarAprovacao(caixinhaId: string, emprestimoUid: string): void {
             sendEmail({
                 to: ADMIN_EMAIL,
                 subject: 'Enviado aprovação de emprestimo via discord',
-                body: `caixinhaId: ${caixinhaId}  emprestimoUid:${emprestimoUid}`
+                message: `caixinhaId: ${caixinhaId}  emprestimoUid:${emprestimoUid}`
             })
         })
         .catch(captureException)
@@ -283,7 +283,7 @@ function emprestimoAprovado(payload: any): void {
             sendEmail({
                 to: ADMIN_EMAIL,
                 subject: `Emprestimo do ${payload.memberName} foi aprovado`,
-                body: `caixinhaId: ${payload.caixinhaid}  emprestimoUid:${payload.emprestimoId}`
+                message: `caixinhaId: ${payload.caixinhaid}  emprestimoUid:${payload.emprestimoId}`
             })
         })
         .catch((e: any) => {

--- a/src/services/finance/DailyBudgetService.ts
+++ b/src/services/finance/DailyBudgetService.ts
@@ -116,7 +116,7 @@ export async function gerarReportDosGastosDoUltimoFinalDeSemana(): Promise<void>
         const email = {
             to: ADMIN_EMAIL,
             subject: 'Gastos do final de semana',
-            body: 'Segue em anexo ',
+            message: 'Segue em anexo ',
             attachmentLink: uploaded
         }
 

--- a/src/services/subscription/SubscriptionService.ts
+++ b/src/services/subscription/SubscriptionService.ts
@@ -56,7 +56,7 @@ export function notifySms(fone: string): Promise<any> {
 export function notifySuccessWithEmail(email: string): void {
     sendEmail({
         subject: 'Assinatura ativa',
-        body: `Ola! este email confirma que sua assinatura esta ativa, se tiver alguma duvida pode entrar em contato comigo
+        message: `Ola! este email confirma que sua assinatura esta ativa, se tiver alguma duvida pode entrar em contato comigo
         *Informações*
                     • [Documentação](https://docs.arbitragem-crypto.cloud/introduction)
                     • [Site](https://market.arbitragem-crypto.cloud/)
@@ -70,7 +70,7 @@ export function notifySuccessWithEmail(email: string): void {
 export function sendEmailBoasVindas(email: string): void {
     sendEmail({
         subject: 'Acesso software de arbitragem',
-        body: `Fala mestre tudo bem, liberei o acesso ao software de arbitragem, estamos liberando novas features
+        message: `Fala mestre tudo bem, liberei o acesso ao software de arbitragem, estamos liberando novas features
 
                     Se tiver alguma opinião/comentário pode me acionar, o link do nosso grupo do WhatsApp https://chat.whatsapp.com/Fyd8t4sXknGHgxlPaaYzKB o grupo do Telegram tem o link na plataforma
 
@@ -207,7 +207,7 @@ async function cancelSubscription(email: string): Promise<void> {
 
 function sendCancellationEmail(name: string, email: string): void {
     const message = getCancellationEmailTemplate(name)
-    sendEmail({ subject: 'Assinatura cancelada', body: message, to: email })
+    sendEmail({ subject: 'Assinatura cancelada', message, to: email })
 }
 
 function notifyDiscordCancellation(name: string, email: string): void {


### PR DESCRIPTION
## Problema

O `communication-service` define o DTO de envio de email em Go assim:

```go
type MailSenderInputDto struct {
    Body      string `json:"message"`   // JSON tag é "message", não "body"
    Recipient string `json:"to"`
    Subject   string `json:"subject"`
    ...
}
```

O bot enviava `{ body: "..." }` no payload, mas o serviço espera `{ message: "..." }`. Por isso o conteúdo chegava vazio e o template renderizava sem texto — exatamente o bug visível no print do email "Acesso software de arbitragem".

## Correção

Renomeia o campo `body` para `message` na interface `EmailPayload` e em todos os 9 arquivos que chamam `sendEmail`:

- `src/services/email/EmailService.ts` — interface `EmailPayload`
- `src/discord/commands/admin/MeConecteiCommand.ts`
- `src/discord/commands/admin/FoodSpendingCommand.ts`
- `src/discord/commands/admin/UpdateInterestCommand.ts`
- `src/discord/commands/finance/BudgetReportCommand.ts`
- `src/services/subscription/SubscriptionService.ts` (3 chamadas)
- `src/services/finance/CaixinhaService.ts` (2 chamadas)
- `src/services/finance/DailyBudgetService.ts`
- `src/services/b3/CryptoArbitrageService.ts`

## Test plan

- [ ] Disparar `sendEmailBoasVindas` para um email de teste e confirmar que o texto do corpo chega no email recebido
- [ ] Verificar emails de juros, alimentação e relatórios de despesa

https://claude.ai/code/session_01L2LtS6WPq4FEeZ8e7uoQNu

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2LtS6WPq4FEeZ8e7uoQNu)_