### PR TITLE
feat: expirar planos vencidos ao executar $ass

### DIFF
--- a/src/discord/commands/subscriptions/ActiveSubscriptionsCommand.ts
+++ b/src/discord/commands/subscriptions/ActiveSubscriptionsCommand.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { getActiveSubscriptions } from '../../../services/subscription/SubscriptionService'
+import { getActiveSubscriptions, expireOverduePlans } from '../../../services/subscription/SubscriptionService'
 import { BaseCommand, DiscordMessage } from '../BaseCommand'
 import { createLogger } from '../../../shared/logger/Logger'
 
@@ -25,6 +25,9 @@ export class ActiveSubscriptionsCommand extends BaseCommand<typeof schema> {
     for (const sub of data.expiringSoon) {
       await message.reply(`${sub.email} — ${sub.expiresIn}`)
     }
+
+    await expireOverduePlans()
+    log.info('Expiração de planos vencidos executada')
   }
 
   protected getUsage() { return '`$ass`' }

--- a/src/services/subscription/SubscriptionService.ts
+++ b/src/services/subscription/SubscriptionService.ts
@@ -232,4 +232,18 @@ export async function addProtestByEvent(event: any): Promise<void> {
     }
 }
 
+export async function expireOverduePlans(): Promise<void> {
+    const token = await getKeycloakToken()
+    const config = {
+        method: 'post',
+        url: 'https://o-auth-managment-server-6d5834301f7a.herokuapp.com/plano/expirar-planos-vencidos',
+        headers: {
+            'Authorization': `Bearer ${token}`
+        }
+    }
+
+    await axios.request(config)
+    log.info('Planos vencidos expirados com sucesso')
+}
+
 export { migrateCollections }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adicionada função `expireOverduePlans` em `SubscriptionService.ts` que chama `POST /plano/expirar-planos-vencidos` com o token Keycloak
- O comando `$ass` agora invoca essa função ao final da execução, expirando automaticamente os planos vencidos após listar as assinaturas ativas

## Test plan

- [ ] Executar `$ass` no Discord e verificar que o endpoint `POST /plano/expirar-planos-vencidos` é chamado com sucesso
- [ ] Confirmar nos logs que aparece `Planos vencidos expirados com sucesso` após `Assinaturas consultadas`
- [ ] Verificar que erros no endpoint de expiração propagam corretamente

https://claude.ai/code/session_019EaM2QY7D6xLn3DPUM3zq8
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019EaM2QY7D6xLn3DPUM3zq8)_