### PR TITLE
fix: round amount_cents to integer before sending to Organizze API

### DIFF
--- a/src/services/finance/DailyBudgetService.ts
+++ b/src/services/finance/DailyBudgetService.ts
@@ -68,7 +68,7 @@ async function createTransaction(
     const categorieId = state.categories.find(
         category => category.name === categorieDescription
     )?.id
-    const amountCents = transactionData.money * 100
+    const amountCents = Math.round(transactionData.money * 100)
     const organizzeService = getOrganizzeService()
     await organizzeService.createTransaction({
         description: transactionData.description.trim(),


### PR DESCRIPTION
## Summary

- `WeekendReportJob` was failing with a 500 error from the Organizze API
- Root cause: `transactionData.money * 100` produced floating-point values like `7998.999999999999` instead of an integer
- Fix: wrap with `Math.round()` in `DailyBudgetService.ts:71` so `amount_cents` is always a valid integer

## Test plan

- [ ] Trigger `WeekendReportJob` manually and confirm transactions are created without 500 errors
- [ ] Verify amounts are correctly rounded (e.g. R$79.99 → 7999 cents)

https://claude.ai/code/session_01X9RTBBbS4qET9zghmJrRE2

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9RTBBbS4qET9zghmJrRE2)_