### PR TITLE
fix: upgrade @discordjs/voice to 0.18.0 to fix voice connection timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@discordjs/opus": "^0.10.0",
-        "@discordjs/voice": "^0.16.1",
+        "@discordjs/voice": "^0.18.0",
         "@ffmpeg-installer/ffmpeg": "^1.0.13",
         "@langchain/core": "^0.3.57",
         "@langchain/openai": "^0.5.11",
@@ -1443,20 +1443,22 @@
       }
     },
     "node_modules/@discordjs/voice": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.16.1.tgz",
-      "integrity": "sha512-uiWiW0Ta6K473yf8zs13RfKuPqm/xU4m4dAidMkIdwqgy1CztbbZBtPLfDkVSKzpW7s6m072C+uQcs4LwF3FhA==",
-      "deprecated": "This version uses deprecated encryption modes. Please use a newer version.",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.18.0.tgz",
+      "integrity": "sha512-BvX6+VJE5/vhD9azV9vrZEt9hL1G+GlOdsQaVl5iv9n87fkXjf3cSwllhR3GdaUC8m6dqT8umXIWtn3yCu4afg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/ws": "^8.5.9",
-        "discord-api-types": "0.37.61",
+        "@types/ws": "^8.5.12",
+        "discord-api-types": "^0.37.103",
         "prism-media": "^1.3.5",
-        "tslib": "^2.6.2",
-        "ws": "^8.14.2"
+        "tslib": "^2.6.3",
+        "ws": "^8.18.0"
       },
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
@@ -6824,9 +6826,9 @@
       "license": "MIT"
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.61",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.61.tgz",
-      "integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw==",
+      "version": "0.37.120",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.120.tgz",
+      "integrity": "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw==",
       "license": "MIT"
     },
     "node_modules/discord.js": {
@@ -14182,9 +14184,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@discordjs/opus": "^0.10.0",
-    "@discordjs/voice": "^0.16.1",
+    "@discordjs/voice": "^0.18.0",
     "@ffmpeg-installer/ffmpeg": "^1.0.13",
     "@langchain/core": "^0.3.57",
     "@langchain/openai": "^0.5.11",


### PR DESCRIPTION
## Problem

The bot was failing to join voice channels, logging:

```
Failed to join voice channel within 20 seconds  (AbortError, @discordjs/voice)
```

The voice connection is created but never reaches `Ready`, so `entersState(..., VoiceConnectionStatus.Ready, 20e3)` aborts after 20s.

## Root cause

`@discordjs/voice@0.16.1` only supports the **deprecated** `xsalsa20_poly1305` voice encryption modes. Discord has since removed these modes, so the UDP/encryption handshake never completes. The package-lock even flagged it: `"This version uses deprecated encryption modes. Please use a newer version."`

## Fix

Upgrade `@discordjs/voice` `0.16.1` → `0.18.0`, which adds the required AEAD encryption modes:

- `aead_aes256_gcm_rtpsize` — handled by Node's native crypto (`aes-256-gcm`, available on the project's Node 23)
- `aead_xchacha20_poly1305_rtpsize` — handled by `libsodium-wrappers`, which is **already** a dependency

No new native modules are required. I intentionally chose `0.18.0` over the latest `0.19.x` because `0.19.x` hard-requires the native `@snazzah/davey` (Rust/napi) module at load time, which adds a build/runtime risk on the deployment host (Heroku worker). `0.18.0` resolves the encryption issue without it.

The voice APIs used by the codebase (`joinVoiceChannel`, `entersState`, `VoiceConnectionStatus`, `AudioPlayerStatus`, `createAudioResource`, `demuxProbe`, `createAudioPlayer`, `VoiceReceiver`, `EndBehaviorType`) are unchanged between 0.16 and 0.18.

## Test plan

- [ ] Run `npm install` and confirm `@discordjs/voice@0.18.0` resolves cleanly
- [ ] Build (`npm run build`) succeeds with no type errors
- [ ] In a guild, run `/play <url>` and confirm the bot joins the voice channel and reaches `Ready` (no 20s timeout)
- [ ] Confirm audio actually plays (encryption negotiation succeeded)

https://claude.ai/code/session_01X8hS9xdbpr7JBrqkBdb6pg

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8hS9xdbpr7JBrqkBdb6pg)_