### PR TITLE
feat(telegram): botão "adcionar cupom mercado" no daily budget

### DIFF
--- a/src/services/finance/MerchantReceiptService.ts
+++ b/src/services/finance/MerchantReceiptService.ts
@@ -19,7 +19,7 @@ export async function analyzeMerchantReceipt(imageUrl: string): Promise<Merchant
       RECEIPTS_ENDPOINT,
       { imageUrl },
       {
-        timeout: 30000,
+        timeout: 50000,
         headers: { 'Content-Type': 'application/json' },
       },
     )

--- a/src/services/finance/MerchantReceiptService.ts
+++ b/src/services/finance/MerchantReceiptService.ts
@@ -1,0 +1,32 @@
+import axios from 'axios'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('MerchantReceiptService')
+
+const RECEIPTS_ENDPOINT =
+  'https://merchant-receipt-analysis-8c20061837f6.herokuapp.com/receipts'
+
+export interface MerchantReceiptResult {
+  success: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: any
+  reason?: string
+}
+
+export async function analyzeMerchantReceipt(imageUrl: string): Promise<MerchantReceiptResult> {
+  try {
+    const response = await axios.post(
+      RECEIPTS_ENDPOINT,
+      { imageUrl },
+      {
+        timeout: 30000,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )
+    log.info({ status: response.status }, 'Merchant receipt analyzed')
+    return { success: true, data: response.data }
+  } catch (err) {
+    log.error({ err }, 'Error analyzing merchant receipt')
+    return { success: false, reason: (err as Error).message }
+  }
+}

--- a/src/telegram/TelegramConfig.ts
+++ b/src/telegram/TelegramConfig.ts
@@ -5,7 +5,7 @@ export const AUTHORIZED_CHAT_ID = 512142034
 
 export const KEYBOARDS = {
   dailyBudget: {
-    keyboard: [['My Daily budget'], ['spent money'], ['batch']] as string[][],
+    keyboard: [['My Daily budget'], ['spent money'], ['batch'], ['adcionar cupom mercado']] as string[][],
     resize_keyboard: true,
   },
   publicUser: {

--- a/src/telegram/TelegramConfig.ts
+++ b/src/telegram/TelegramConfig.ts
@@ -5,7 +5,7 @@ export const AUTHORIZED_CHAT_ID = 512142034
 
 export const KEYBOARDS = {
   dailyBudget: {
-    keyboard: [['My Daily budget'], ['spent money'], ['batch'], ['adcionar cupom mercado']] as string[][],
+    keyboard: [['My Daily budget'], ['spent money'], ['batch'], ['adicionar cupom mercado']] as string[][],
     resize_keyboard: true,
   },
   publicUser: {

--- a/src/telegram/handlers/DailyBudgetHandler.ts
+++ b/src/telegram/handlers/DailyBudgetHandler.ts
@@ -8,6 +8,7 @@ import {
 } from '../../services/finance/DailyBudgetService'
 import { resolveMoneyToBrl } from '../../services/finance/CurrencyService'
 import { extractTransactionsFromImage, type ExtractedTransaction } from '../../services/finance/BankNotificationImageService'
+import { analyzeMerchantReceipt } from '../../services/finance/MerchantReceiptService'
 import { KEYBOARDS } from '../TelegramConfig'
 import { createLogger } from '../../shared/logger/Logger'
 
@@ -16,6 +17,7 @@ const log = createLogger('DailyBudgetHandler')
 const state = {
   awaitResponseSpentMoney: false,
   batchResponse: false,
+  awaitCouponImage: false,
   batchInserts: [] as { money: string; description: string }[],
 }
 
@@ -73,6 +75,11 @@ export function registerDailyBudgetHandlers(bot: any): void {
     ctx.reply('informe o valor e descricao separado por virgula')
   })
 
+  bot.hears('adcionar cupom mercado', (ctx: Context) => {
+    state.awaitCouponImage = true
+    ctx.reply('Envie a imagem do cupom do mercado.')
+  })
+
   bot.hears(['Info', 'Links', 'Link'], (ctx: Context) => {
     ctx.replyWithMarkdownV2(
       `*Informações*\n• [Documentação](https://docs.arbitragem-crypto.cloud/introduction)\n• [Site](https://market.arbitragem-crypto.cloud/)\n• [Plataforma](https://arbitragem-crypto.cloud/)\n• [Comunidade](https://comunidade.arbitragem-crypto.cloud/)`,
@@ -104,6 +111,24 @@ export function registerDailyBudgetHandlers(bot: any): void {
     const largestPhoto = photos[photos.length - 1]
     if (!largestPhoto) {
       await ctx.reply('Não foi possível obter a imagem.')
+      return
+    }
+
+    if (state.awaitCouponImage) {
+      state.awaitCouponImage = false
+      await ctx.reply('Analisando cupom do mercado...')
+      try {
+        const fileLink = await ctx.telegram.getFileLink(largestPhoto.file_id)
+        const result = await analyzeMerchantReceipt(fileLink.href)
+        if (!result.success) {
+          await ctx.reply(`Não consegui analisar o cupom.${result.reason ? ` ${result.reason}` : ''}`)
+          return
+        }
+        await ctx.reply('Cupom do mercado registrado com sucesso!')
+      } catch (err) {
+        log.error({ err }, 'Error processing merchant receipt image')
+        await ctx.reply('Ocorreu um erro ao processar o cupom. Tente novamente.')
+      }
       return
     }
 

--- a/src/telegram/handlers/DailyBudgetHandler.ts
+++ b/src/telegram/handlers/DailyBudgetHandler.ts
@@ -75,7 +75,7 @@ export function registerDailyBudgetHandlers(bot: any): void {
     ctx.reply('informe o valor e descricao separado por virgula')
   })
 
-  bot.hears('adcionar cupom mercado', (ctx: Context) => {
+  bot.hears('adicionar cupom mercado', (ctx: Context) => {
     state.awaitCouponImage = true
     ctx.reply('Envie a imagem do cupom do mercado.')
   })


### PR DESCRIPTION
## Resumo

Adiciona uma nova opção no teclado do fluxo de **daily budget** do Telegram: **"adcionar cupom mercado"**.

Ao clicar no botão, o bot passa a aguardar **apenas uma imagem** (do cupom do mercado). Quando a imagem chega, ele:
1. Obtém o link da imagem via Telegram.
2. Faz um `POST` para `https://merchant-receipt-analysis-8c20061837f6.herokuapp.com/receipts` com o corpo `{ "imageUrl": "<link>" }`.
3. Se a request for concluída com sucesso, exibe a mensagem de confirmação `Cupom do mercado registrado com sucesso!`.

## Mudanças

- **`src/telegram/TelegramConfig.ts`** — novo botão `adcionar cupom mercado` no teclado `dailyBudget`.
- **`src/telegram/handlers/DailyBudgetHandler.ts`** — novo estado `awaitCouponImage`, handler do botão e ramificação do handler de foto para direcionar a imagem do cupom ao novo fluxo (sem afetar o fluxo de notificação bancária existente).
- **`src/services/finance/MerchantReceiptService.ts`** (novo) — serviço `analyzeMerchantReceipt(imageUrl)` que faz o POST para a API de análise de cupons.

## Testes

- `npx tsc --noEmit` — 0 erros.
- `npx jest` — 79 testes passando.

https://claude.ai/code/session_01PvoCYqwe2mdMHueDfNzyfP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvoCYqwe2mdMHueDfNzyfP)_