### PR TITLE
feat: relatório mensal de compras em PDF por email no fechamento do mês

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ AMQP_CONNECTION=amqp://adm:123456@localhost:5672/virtualhost
 # URL base do serviço de comunicação (SMS/e-mail); opcional — há default no código
 COMMUNICATION_SERVER_URL=
 CAIXINHA_SERVER_URL=
+# URL base do serviço de compras de mercado (endpoint /reports/:month); opcional — há default no código
+COMPRAS_MERCADO_API_URL=
 KEY_OPEN_AI=
 FINANCE_API_AUTH=
 TELEGRAM_API_KEY=

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -53,6 +53,12 @@ const envSchema = z.object({
   CAIXINHA_KEY: z.string().optional(),
   CAIXINHA_SERVER_URL: z.string().optional(),
 
+  /**
+   * URL base do serviço de compras de mercado (merchant-receipt-analysis),
+   * que expõe o endpoint GET /reports/:month. Opcional — há default no código.
+   */
+  COMPRAS_MERCADO_API_URL: z.string().optional(),
+
   // ── Comunicação ────────────────────────────────────────────────────────
   TELEGRAM_API_KEY: z.string().optional(),
   AMQP_CONNECTION: z.string().optional(),

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -5,6 +5,7 @@ import { WeekendReportJob } from './jobs/WeekendReportJob'
 import { DailyBudgetJob } from './jobs/DailyBudgetJob'
 import { QuizJob } from './jobs/QuizJob'
 import { YoutubeRssJob } from './jobs/YoutubeRssJob'
+import { MonthlyMarketReportJob } from './jobs/MonthlyMarketReportJob'
 import { createLogger } from '../shared/logger/Logger'
 
 const log = createLogger('scheduler')
@@ -18,6 +19,7 @@ export function registerJobs(): void {
   scheduler.register(new DailyBudgetJob())
   scheduler.register(new QuizJob())
   scheduler.register(new YoutubeRssJob())
+  scheduler.register(new MonthlyMarketReportJob())
 
   log.info('All jobs registered')
 }

--- a/src/scheduler/jobs/MonthlyMarketReportJob.ts
+++ b/src/scheduler/jobs/MonthlyMarketReportJob.ts
@@ -1,0 +1,89 @@
+import { IJob } from '../IJob'
+import { fetchMonthlyReport } from '../../services/finance/ComprasMercadoReportService'
+import {
+  gerarPdfRelatorioMensalCompras,
+  mesAnoLabel,
+} from '../../services/pdf/MonthlyMarketReportPdf'
+import { upload } from '../../services/upload/UploadService'
+import { sendEmail } from '../../services/email/EmailService'
+import { ADMIN_EMAIL } from '../../config/constants'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('MonthlyMarketReportJob')
+
+/**
+ * Retorna true se `date` for o último dia do mês.
+ * node-cron não suporta o coringa "L", então o job roda todo dia e este
+ * guard garante que o relatório só é gerado no fechamento do mês.
+ */
+export function ehUltimoDiaDoMes(date: Date): boolean {
+  const amanha = new Date(date)
+  amanha.setDate(date.getDate() + 1)
+  return amanha.getDate() === 1
+}
+
+/** Formata uma data como "YYYY-MM" (mês de referência do endpoint). */
+export function formatMonth(date: Date): string {
+  const ano = date.getFullYear()
+  const mes = String(date.getMonth() + 1).padStart(2, '0')
+  return `${ano}-${mes}`
+}
+
+/**
+ * Roda diariamente às 23:30 e, no último dia do mês, consome o endpoint
+ * GET /reports/:month, monta um PDF visual, sobe para o storage e envia
+ * como anexo no e-mail do admin.
+ */
+export class MonthlyMarketReportJob implements IJob {
+  readonly cronExpression = '30 23 * * *'
+
+  async run(): Promise<void> {
+    const hoje = new Date()
+    if (!ehUltimoDiaDoMes(hoje)) {
+      return
+    }
+
+    const month = formatMonth(hoje)
+    log.info({ month }, 'Último dia do mês — gerando relatório de compras')
+
+    const report = await fetchMonthlyReport(month)
+    if (!report) {
+      log.error({ month }, 'Relatório vazio — abortando')
+      return
+    }
+
+    const pdfPath = gerarPdfRelatorioMensalCompras(report, month)
+    // Garante que o stream do PDF terminou de escrever antes do upload.
+    await new Promise(resolve => setTimeout(resolve, 1500))
+
+    const attachmentLink = await upload(pdfPath)
+    if (!attachmentLink) {
+      log.error({ month }, 'Upload do PDF falhou — e-mail não enviado')
+      return
+    }
+
+    const ref = mesAnoLabel(month)
+    sendEmail({
+      to: ADMIN_EMAIL,
+      subject: `Relatório de compras de mercado — ${ref}`,
+      message: [
+        `Segue em anexo o relatório de compras de mercado de ${ref}.`,
+        ``,
+        `Total gasto: ${formatBRL(report.totalSpent)}`,
+        `Compras: ${report.purchaseCount}`,
+        `Ticket médio: ${formatBRL(report.averageTicket)}`,
+        `Itens comprados: ${report.itemCount}`,
+      ].join('\n'),
+      attachmentLink,
+    })
+
+    log.info({ month, to: ADMIN_EMAIL }, 'E-mail do relatório mensal enviado')
+  }
+}
+
+function formatBRL(value: number): string {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  }).format(Number.isFinite(value) ? value : 0)
+}

--- a/src/services/finance/ComprasMercadoReportService.ts
+++ b/src/services/finance/ComprasMercadoReportService.ts
@@ -1,0 +1,62 @@
+import axios from 'axios'
+import { createLogger } from '../../shared/logger/Logger'
+import { env } from '../../config/env'
+
+const log = createLogger('ComprasMercadoReportService')
+
+const DEFAULT_BASE_URL =
+  'https://merchant-receipt-analysis-8c20061837f6.herokuapp.com'
+
+export interface TopStore {
+  store: string
+  totalSpent: number
+  [key: string]: unknown
+}
+
+export interface StoreRankingEntry {
+  store: string
+  totalSpent: number
+  visitCount: number
+  averageTicket: number
+  [key: string]: unknown
+}
+
+export interface CategorySpending {
+  category: string
+  totalSpent: number
+  percentage: number
+  itemCount: number
+  [key: string]: unknown
+}
+
+export interface MonthlyReport {
+  totalSpent: number
+  purchaseCount: number
+  averageTicket: number
+  itemCount: number
+  topStore: TopStore | null
+  storeRanking: StoreRankingEntry[]
+  spendingByCategory: CategorySpending[]
+  [key: string]: unknown
+}
+
+function baseUrl(): string {
+  return env.COMPRAS_MERCADO_API_URL ?? DEFAULT_BASE_URL
+}
+
+/**
+ * Consome o endpoint GET /reports/:month (formato YYYY-MM) do serviço de
+ * análise de compras de mercado e devolve o relatório consolidado do mês.
+ */
+export async function fetchMonthlyReport(month: string): Promise<MonthlyReport> {
+  const url = `${baseUrl()}/reports/${month}`
+  log.info({ url, month }, 'Buscando relatório mensal de compras')
+
+  const { data } = await axios.get<MonthlyReport>(url, { timeout: 30_000 })
+
+  log.info(
+    { month, totalSpent: data?.totalSpent, purchaseCount: data?.purchaseCount },
+    'Relatório mensal de compras recebido',
+  )
+  return data
+}

--- a/src/services/pdf/MonthlyMarketReportPdf.ts
+++ b/src/services/pdf/MonthlyMarketReportPdf.ts
@@ -1,0 +1,273 @@
+import PDFDocument from 'pdfkit'
+import fs from 'fs'
+import path from 'path'
+import { randomUUID } from 'crypto'
+import {
+  MonthlyReport,
+  StoreRankingEntry,
+  CategorySpending,
+} from '../finance/ComprasMercadoReportService'
+
+const MESES = [
+  'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho',
+  'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro',
+]
+
+// Paleta usada nas barras/cards
+const COLORS = {
+  primary: '#2563eb',
+  primaryDark: '#1e3a8a',
+  text: '#1f2937',
+  muted: '#6b7280',
+  cardBg: '#eff6ff',
+  barBg: '#e5e7eb',
+  rowAlt: '#f3f4f6',
+}
+
+function formatBRL(value: number): string {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  }).format(Number.isFinite(value) ? value : 0)
+}
+
+/** Converte "YYYY-MM" em "Junho/2026". */
+export function mesAnoLabel(month: string): string {
+  const [ano = '', mes = ''] = month.split('-')
+  const idx = parseInt(mes, 10) - 1
+  return `${MESES[idx] ?? mes}/${ano}`
+}
+
+// Acesso defensivo: a forma exata dos itens dos arrays não é 100% garantida.
+function num(value: unknown): number {
+  const n = typeof value === 'string' ? parseFloat(value) : (value as number)
+  return Number.isFinite(n) ? n : 0
+}
+
+function pick(obj: Record<string, unknown>, keys: string[]): unknown {
+  for (const k of keys) {
+    if (obj && obj[k] !== undefined && obj[k] !== null) return obj[k]
+  }
+  return undefined
+}
+
+/**
+ * Gera um PDF visual com o relatório mensal de compras de mercado
+ * e retorna o caminho absoluto do arquivo.
+ */
+export function gerarPdfRelatorioMensalCompras(
+  report: MonthlyReport,
+  month: string,
+): string {
+  const doc = new PDFDocument({ size: 'A4', margin: 48 })
+  const filename = `${randomUUID()}-relatorio-compras.pdf`
+  const absolutePath = path.resolve(__dirname, '..', '..', '..', filename)
+  doc.pipe(fs.createWriteStream(absolutePath))
+
+  const left = doc.page.margins.left
+  const usableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right
+
+  // ── Cabeçalho ────────────────────────────────────────────────────────────
+  doc
+    .fillColor(COLORS.primaryDark)
+    .fontSize(22)
+    .text('Relatório de Compras de Mercado', left, 48)
+  doc
+    .fillColor(COLORS.muted)
+    .fontSize(13)
+    .text(mesAnoLabel(month), { continued: false })
+  doc.moveDown(1)
+
+  // ── Cards de resumo (2 x 2) ──────────────────────────────────────────────
+  const cards: Array<{ label: string; value: string }> = [
+    { label: 'Total gasto', value: formatBRL(num(report.totalSpent)) },
+    { label: 'Compras', value: String(num(report.purchaseCount)) },
+    { label: 'Ticket médio', value: formatBRL(num(report.averageTicket)) },
+    { label: 'Itens comprados', value: String(num(report.itemCount)) },
+  ]
+
+  const gap = 12
+  const cardW = (usableWidth - gap) / 2
+  const cardH = 58
+  const startY = doc.y
+  cards.forEach((card, i) => {
+    const col = i % 2
+    const row = Math.floor(i / 2)
+    const x = left + col * (cardW + gap)
+    const y = startY + row * (cardH + gap)
+
+    doc.roundedRect(x, y, cardW, cardH, 8).fill(COLORS.cardBg)
+    doc
+      .fillColor(COLORS.muted)
+      .fontSize(10)
+      .text(card.label.toUpperCase(), x + 14, y + 12, { width: cardW - 28 })
+    doc
+      .fillColor(COLORS.primaryDark)
+      .fontSize(18)
+      .text(card.value, x + 14, y + 28, { width: cardW - 28 })
+  })
+  doc.y = startY + 2 * cardH + gap + 18
+
+  // ── Loja destaque ────────────────────────────────────────────────────────
+  if (report.topStore) {
+    const storeName =
+      (pick(report.topStore, ['store', 'name', 'storeName']) as string) ?? '—'
+    const storeTotal = num(pick(report.topStore, ['totalSpent', 'total', 'spent']))
+    const y = doc.y
+    doc.roundedRect(left, y, usableWidth, 46, 8).fill(COLORS.primary)
+    doc
+      .fillColor('#ffffff')
+      .fontSize(10)
+      .text('LOJA DESTAQUE DO MÊS', left + 14, y + 9)
+    doc
+      .fillColor('#ffffff')
+      .fontSize(15)
+      .text(`${storeName}  —  ${formatBRL(storeTotal)}`, left + 14, y + 23)
+    doc.y = y + 46 + 18
+  }
+
+  // ── Ranking de lojas ─────────────────────────────────────────────────────
+  const ranking = Array.isArray(report.storeRanking) ? report.storeRanking : []
+  if (ranking.length > 0) {
+    sectionTitle(doc, 'Ranking de lojas', left)
+    const cols = [
+      { title: 'Loja', width: usableWidth * 0.4, align: 'left' as const },
+      { title: 'Gasto', width: usableWidth * 0.22, align: 'right' as const },
+      { title: 'Visitas', width: usableWidth * 0.18, align: 'right' as const },
+      { title: 'Ticket médio', width: usableWidth * 0.2, align: 'right' as const },
+    ]
+    tableHeader(doc, cols, left)
+    ranking.forEach((entry: StoreRankingEntry, i) => {
+      ensureSpace(doc, 22)
+      const y = doc.y
+      if (i % 2 === 1) {
+        doc.rect(left, y - 2, usableWidth, 18).fill(COLORS.rowAlt)
+      }
+      const store =
+        (pick(entry, ['store', 'name', 'storeName']) as string) ?? '—'
+      const total = num(pick(entry, ['totalSpent', 'total', 'spent']))
+      const visits = num(pick(entry, ['visitCount', 'visits', 'purchaseCount']))
+      const avg = num(pick(entry, ['averageTicket', 'avgTicket', 'average']))
+      rowCells(
+        doc,
+        [store, formatBRL(total), String(visits), formatBRL(avg)],
+        cols,
+        left,
+        y,
+      )
+      doc.y = y + 18
+    })
+    doc.moveDown(1)
+  }
+
+  // ── Gastos por categoria (barras) ────────────────────────────────────────
+  const categories = Array.isArray(report.spendingByCategory)
+    ? report.spendingByCategory
+    : []
+  if (categories.length > 0) {
+    sectionTitle(doc, 'Gastos por categoria', left)
+    categories.forEach((cat: CategorySpending) => {
+      ensureSpace(doc, 34)
+      const name = (pick(cat, ['category', 'name']) as string) ?? '—'
+      const total = num(pick(cat, ['totalSpent', 'value', 'total']))
+      const items = num(pick(cat, ['itemCount', 'items', 'count']))
+      const pct = num(pick(cat, ['percentage', 'percent', 'pct']))
+
+      const y = doc.y
+      doc
+        .fillColor(COLORS.text)
+        .fontSize(11)
+        .text(name, left, y, { width: usableWidth * 0.55, continued: false })
+      doc
+        .fillColor(COLORS.muted)
+        .fontSize(10)
+        .text(
+          `${formatBRL(total)}  ·  ${items} itens  ·  ${pct.toFixed(1)}%`,
+          left,
+          y,
+          { width: usableWidth, align: 'right' },
+        )
+
+      // Barra proporcional ao percentual
+      const barY = y + 16
+      const barH = 8
+      doc.roundedRect(left, barY, usableWidth, barH, 4).fill(COLORS.barBg)
+      const filled = Math.max(0, Math.min(100, pct)) / 100 * usableWidth
+      if (filled > 0) {
+        doc.roundedRect(left, barY, filled, barH, 4).fill(COLORS.primary)
+      }
+      doc.y = barY + barH + 12
+    })
+  }
+
+  // ── Rodapé ───────────────────────────────────────────────────────────────
+  doc
+    .fillColor(COLORS.muted)
+    .fontSize(8)
+    .text(
+      `Gerado automaticamente em ${new Date().toLocaleString('pt-BR')}`,
+      left,
+      doc.page.height - doc.page.margins.bottom - 12,
+      { width: usableWidth, align: 'center' },
+    )
+
+  doc.end()
+  return absolutePath
+}
+
+// ── Helpers de layout ────────────────────────────────────────────────────────
+
+function sectionTitle(doc: PDFKit.PDFDocument, text: string, left: number): void {
+  ensureSpace(doc, 40)
+  doc
+    .fillColor(COLORS.primaryDark)
+    .fontSize(15)
+    .text(text, left, doc.y)
+  doc.moveDown(0.4)
+}
+
+interface Col {
+  title: string
+  width: number
+  align: 'left' | 'right'
+}
+
+function tableHeader(doc: PDFKit.PDFDocument, cols: Col[], left: number): void {
+  const y = doc.y
+  doc.rect(left, y - 2, cols.reduce((a, c) => a + c.width, 0), 18).fill(COLORS.primaryDark)
+  let x = left
+  doc.fillColor('#ffffff').fontSize(10)
+  for (const col of cols) {
+    doc.text(col.title, x + 6, y + 2, { width: col.width - 12, align: col.align })
+    x += col.width
+  }
+  doc.y = y + 18
+}
+
+function rowCells(
+  doc: PDFKit.PDFDocument,
+  values: string[],
+  cols: Col[],
+  left: number,
+  y: number,
+): void {
+  let x = left
+  doc.fillColor(COLORS.text).fontSize(10)
+  values.forEach((value, i) => {
+    const col = cols[i]
+    if (!col) return
+    doc.text(value, x + 6, y + 2, {
+      width: col.width - 12,
+      align: col.align,
+      lineBreak: false,
+    })
+    x += col.width
+  })
+}
+
+function ensureSpace(doc: PDFKit.PDFDocument, needed: number): void {
+  const bottom = doc.page.height - doc.page.margins.bottom
+  if (doc.y + needed > bottom) {
+    doc.addPage()
+  }
+}

--- a/tests/unit/scheduler/MonthlyMarketReportJob.test.ts
+++ b/tests/unit/scheduler/MonthlyMarketReportJob.test.ts
@@ -1,0 +1,43 @@
+// Evita a validação de env (process.exit) ao importar o job e suas dependências.
+jest.mock('../../../src/config/env', () => ({ env: {} }))
+
+import {
+  ehUltimoDiaDoMes,
+  formatMonth,
+} from '../../../src/scheduler/jobs/MonthlyMarketReportJob'
+
+describe('ehUltimoDiaDoMes', () => {
+  it('retorna true no último dia de um mês de 30 dias', () => {
+    expect(ehUltimoDiaDoMes(new Date(2026, 5, 30))).toBe(true) // 30/jun
+  })
+
+  it('retorna true no último dia de um mês de 31 dias', () => {
+    expect(ehUltimoDiaDoMes(new Date(2026, 6, 31))).toBe(true) // 31/jul
+  })
+
+  it('retorna true em 28/fev de ano não bissexto', () => {
+    expect(ehUltimoDiaDoMes(new Date(2026, 1, 28))).toBe(true)
+  })
+
+  it('retorna true em 29/fev de ano bissexto', () => {
+    expect(ehUltimoDiaDoMes(new Date(2024, 1, 29))).toBe(true)
+  })
+
+  it('retorna false em um dia no meio do mês', () => {
+    expect(ehUltimoDiaDoMes(new Date(2026, 5, 15))).toBe(false)
+  })
+
+  it('retorna false no penúltimo dia do mês', () => {
+    expect(ehUltimoDiaDoMes(new Date(2026, 5, 29))).toBe(false)
+  })
+})
+
+describe('formatMonth', () => {
+  it('formata como YYYY-MM com zero à esquerda', () => {
+    expect(formatMonth(new Date(2026, 5, 30))).toBe('2026-06')
+  })
+
+  it('formata dezembro corretamente', () => {
+    expect(formatMonth(new Date(2026, 11, 31))).toBe('2026-12')
+  })
+})

--- a/tests/unit/services/finance/ComprasMercadoReportService.test.ts
+++ b/tests/unit/services/finance/ComprasMercadoReportService.test.ts
@@ -1,0 +1,45 @@
+import axios from 'axios'
+import { fetchMonthlyReport } from '../../../../src/services/finance/ComprasMercadoReportService'
+
+jest.mock('axios')
+jest.mock('../../../../src/shared/logger/Logger', () => ({
+  createLogger: () => ({ info: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}))
+// Evita rodar a validação de env (process.exit) ao importar o service.
+jest.mock('../../../../src/config/env', () => ({ env: {} }))
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('fetchMonthlyReport', () => {
+  const report = {
+    totalSpent: 1234.5,
+    purchaseCount: 7,
+    averageTicket: 176.36,
+    itemCount: 42,
+    topStore: { store: 'Mercado X', totalSpent: 800 },
+    storeRanking: [],
+    spendingByCategory: [],
+  }
+
+  it('chama o endpoint /reports/:month e retorna os dados', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: report })
+
+    const result = await fetchMonthlyReport('2026-06')
+
+    expect(result).toEqual(report)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://merchant-receipt-analysis-8c20061837f6.herokuapp.com/reports/2026-06',
+      expect.objectContaining({ timeout: 30_000 }),
+    )
+  })
+
+  it('propaga o erro quando a API falha', async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error('network error'))
+
+    await expect(fetchMonthlyReport('2026-06')).rejects.toThrow('network error')
+  })
+})


### PR DESCRIPTION
## O que faz

No **último dia de cada mês**, o bot consome o endpoint `GET /reports/:month` (documentado em [`compras-mercado-data-analytics#2`](https://github.com/Jean1dev/compras-mercado-data-analytics/pull/2)), monta um **PDF visual** a partir dos dados, sobe o arquivo para o nosso storage e o envia como **anexo no e-mail do admin**.

## Como funciona

`MonthlyMarketReportJob` roda diariamente às 23:30. Como o `node-cron` não suporta o coringa `L` (último dia do mês), há um guard interno (`ehUltimoDiaDoMes`) que só dispara o fluxo no fechamento do mês. O fluxo é:

`fetchMonthlyReport(YYYY-MM)` → `gerarPdfRelatorioMensalCompras()` → `upload()` → `sendEmail({ to: ADMIN_EMAIL, attachmentLink })`

Reusa a infraestrutura existente (`UploadService`, `EmailService`, `pdfkit`), seguindo o mesmo padrão de `BudgetReportCommand`.

## Arquivos

- **`src/services/finance/ComprasMercadoReportService.ts`** — consome `GET /reports/:month` (tipa a resposta: `totalSpent`, `purchaseCount`, `averageTicket`, `itemCount`, `topStore`, `storeRanking`, `spendingByCategory`).
- **`src/services/pdf/MonthlyMarketReportPdf.ts`** — gera o PDF visual: cards de resumo, loja destaque, tabela de ranking de lojas e gastos por categoria com barras proporcionais.
- **`src/scheduler/jobs/MonthlyMarketReportJob.ts`** — orquestra o fluxo, com guard de último dia do mês.
- **`src/scheduler/index.ts`** — registra o job.
- **`src/config/env.ts` / `.env.example`** — `COMPRAS_MERCADO_API_URL` configurável (default = serviço atual `merchant-receipt-analysis`).
- **Testes** — guard de data (`ehUltimoDiaDoMes`/`formatMonth`) e consumo do endpoint (axios mockado).

## Validação

- ✅ `tsc --noEmit` limpo nos arquivos novos
- ✅ Suíte completa: **89 testes passando** (10 novos)
- ✅ Smoke test: PDF gerado e renderizado (preview abaixo)

## Preview do PDF

O layout foi validado gerando o PDF com dados de exemplo (ver imagem compartilhada na conversa): cabeçalho com mês de referência, 4 cards de resumo, faixa de loja destaque, tabela de ranking e barras por categoria.

## Premissas

- **Base URL**: `COMPRAS_MERCADO_API_URL` com default para `https://merchant-receipt-analysis-8c20061837f6.herokuapp.com` (mesmo host do POST `/receipts` usado no fluxo do Telegram).
- **Sem autenticação** no endpoint (PR não especifica). Se exigir token, é trivial adicionar header configurável.
- **Mês reportado** = o mês que está terminando (mês corrente no último dia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lsf84iha8KRtbquz4pPSJL)_