### PR TITLE
Adiciona retry com backoff no login do Discord

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -27,7 +27,22 @@ const client = new Client({
   ],
 })
 
-client.login(env.BOT_TOKEN)
+async function startBot(retries = 5, delay = 2000): Promise<void> {
+  try {
+    await client.login(env.BOT_TOKEN)
+  } catch (err) {
+    log.error({ err, retriesLeft: retries }, 'Falha ao logar no Discord')
+    if (retries > 0) {
+      setTimeout(() => {
+        startBot(retries - 1, delay * 2)
+      }, delay)
+    } else {
+      captureException(err)
+    }
+  }
+}
+
+startBot()
 
 const prefix: string = process.env.NODE_ENV === 'dev' ? '!' : '$'
 log.info({ prefix }, 'Comando do bot')


### PR DESCRIPTION
## Contexto

O Sentry registrou um `FetchError: Invalid response body while trying to fetch https://discord.com/api/v9/gateway/bot: Premature close` como **unhandled promise rejection** na inicialização do bot em produção.

### Causa

Em `src/bot.ts`, a chamada `client.login(env.BOT_TOKEN)` não era aguardada nem tinha tratamento de erro. O discord.js v13 usa `node-fetch` internamente para buscar a URL do gateway. Quando a conexão TCP com o Discord cai no meio do download da resposta (`Premature close` — erro transitório de rede), a Promise rejeitada não tinha quem a capturasse e borbulhava até o handler global de `unhandledRejection`, sendo reportada ao Sentry com `handled: false`.

## Mudança

Envolve o `login()` em uma função `startBot()` com **retry e backoff exponencial** (5 tentativas, começando em 2s). Falhas transitórias agora resultam em uma nova tentativa de conexão; só após esgotar as tentativas o erro é reportado ao Sentry.

```js
async function startBot(retries = 5, delay = 2000) {
  try {
    await client.login(env.BOT_TOKEN)
  } catch (err) {
    log.error({ err, retriesLeft: retries }, 'Falha ao logar no Discord')
    if (retries > 0) {
      setTimeout(() => startBot(retries - 1, delay * 2), delay)
    } else {
      captureException(err)
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013ed5LrMXP2ViFwdNoNjHqh)_