### PR TITLE
fix(music): dribla muro anti-bot do YouTube (cookies + clients modernos)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,13 @@ ADMIN_KEYCLOACK_PASSWORD=
 ADMIN_KEYCLOACK_CLIENT_ID=
 CLOUD_CONVERT_API=
 CRYPTO_SERVICE_DB=
+# ── Player de música (YouTube) ──────────────────────────────────────────────
+# Em IP de datacenter (Heroku/VPS) o YouTube exige cookies de conta logada para
+# não cair no muro "Sign in to confirm you're not a bot".
+# Gere o cookies.txt (extensão "Get cookies.txt" no navegador logado) e:
+#   base64 -w0 cookies.txt   → cole o resultado abaixo
+YOUTUBE_COOKIES_B64=
+# Alternativa: caminho de um cookies.txt já presente no disco (tem prioridade)
+YOUTUBE_COOKIES_FILE=
+# Override opcional dos player clients do yt-dlp (default: tv,web_safari)
+YTDLP_PLAYER_CLIENT=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,20 @@
 FROM node:23
 
-# Instalar o yt-dlp usando o Python no contêiner
-RUN apt-get update && apt-get install -y python3 && \
-    curl -L https://yt-dl.org/downloads/latest/yt-dlp -o /usr/local/bin/yt-dlp && \
-    chmod a+rx /usr/local/bin/yt-dlp
+# Python é dependência de runtime do yt-dlp
+RUN apt-get update && apt-get install -y python3 && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY package*.json .env ./
 
 RUN npm install
+
+# O app usa o binário yt-dlp empacotado pelo youtube-dl-exec, que costuma
+# estar desatualizado. O YouTube muda assinatura/anti-bot com frequência, então
+# baixamos a release mais recente do yt-dlp sobre o binário bundled no build.
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp \
+      -o node_modules/youtube-dl-exec/bin/yt-dlp && \
+    chmod a+rx node_modules/youtube-dl-exec/bin/yt-dlp
 
 COPY . .
 

--- a/docs/TROUBLESHOOTING_MUSICA_VOZ.md
+++ b/docs/TROUBLESHOOTING_MUSICA_VOZ.md
@@ -193,6 +193,40 @@ Avisos de `SABR streaming` / `No supported JavaScript runtime` são comuns; enqu
 - Confirme o ffmpeg: `node -e "console.log(require('@discordjs/voice').generateDependencyReport())"` deve mostrar `FFmpeg` e `libopus: yes`.
 - Adicione logs temporários em `subcription.ts` (`audioPlayer.on('stateChange')` e dentro de `processQueue`) para ver se o resource chega a `Playing` ou cai em `Idle`/erro.
 
+### B.5 — `Sign in to confirm you're not a bot` (muro anti-bot do YouTube)
+
+Sintoma exato no stderr do yt-dlp:
+```
+ERROR: [youtube] <id>: Sign in to confirm you're not a bot.
+Use --cookies-from-browser or --cookies for the authentication.
+```
+
+**Causa:** o YouTube marca **IPs de datacenter** (Heroku/VPS) como suspeitos e
+exige autenticação. Diferente do 403 (yt-dlp velho), aqui ele bloqueia já na
+extração de metadados (`Track.from`). Piora porque os clients `android`/`ios`
+passaram a exigir **PO token** e o `web` sem cookies num IP flagrado cai direto
+no muro — por isso o antigo `player_client=android,ios,web` deixou de ajudar.
+
+**Correção (implementada em `src/handlers/music/ytdlp-options.ts`):**
+
+1. **Cookies de uma conta logada** (forma confiável em IP de datacenter). Use,
+   de preferência, uma conta descartável:
+   - No navegador logado no YouTube, exporte `cookies.txt` (formato Netscape —
+     extensão "Get cookies.txt").
+   - `base64 -w0 cookies.txt` e cole o resultado na config var
+     **`YOUTUBE_COOKIES_B64`** (no Heroku: `heroku config:set YOUTUBE_COOKIES_B64=...`).
+   - Alternativa: aponte **`YOUTUBE_COOKIES_FILE`** para um cookies.txt no disco.
+   - O código materializa o arquivo no boot e passa `--cookies` ao yt-dlp.
+
+2. **Clients modernos** sem PO token: default `tv,web_safari` (sobrescreva com
+   **`YTDLP_PLAYER_CLIENT`** se precisar).
+
+3. **yt-dlp atualizado**: o `Dockerfile` baixa a release mais recente do yt-dlp
+   por cima do binário empacotado pelo `youtube-dl-exec` no build.
+
+> Cookies vencem/expiram. Se o muro voltar depois de semanas, **gere um
+> `cookies.txt` novo** e atualize a config var.
+
 ---
 
 ## C. Crash no boot: `Cannot read properties of null (reading 'client')`

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -48,6 +48,16 @@ const envSchema = z.object({
     .optional()
     .transform(v => (v ? parseInt(v, 10) : 0)),
 
+  /**
+   * Player do YouTube (música) — driblar o anti-bot em IP de datacenter.
+   * - YOUTUBE_COOKIES_B64: cookies.txt (formato Netscape) em base64.
+   * - YOUTUBE_COOKIES_FILE: caminho de um cookies.txt já no disco.
+   * - YTDLP_PLAYER_CLIENT: override da lista de clients do yt-dlp.
+   */
+  YOUTUBE_COOKIES_B64: z.string().optional(),
+  YOUTUBE_COOKIES_FILE: z.string().optional(),
+  YTDLP_PLAYER_CLIENT: z.string().optional(),
+
   // ── Finanças ───────────────────────────────────────────────────────────
   FINANCE_API_AUTH: z.string().optional(),
   CAIXINHA_KEY: z.string().optional(),

--- a/src/handlers/music/track.ts
+++ b/src/handlers/music/track.ts
@@ -1,5 +1,6 @@
 import { createAudioResource, demuxProbe } from '@discordjs/voice'
 import { createLogger } from '../../shared/logger/Logger'
+import { ytdlpCommonOptions } from './ytdlp-options'
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { exec } = require('youtube-dl-exec')
 
@@ -41,11 +42,7 @@ export class Track {
           output: '-',
           quiet: true,
           format: 'bestaudio[ext=webm]/bestaudio/best',
-          noWarnings: true,
-          extractorArgs: 'youtube:player_client=android,ios,web',
-          addHeader: [
-            'User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-          ],
+          ...ytdlpCommonOptions(),
         },
         { stdio: ['ignore', 'pipe', 'pipe'] },
       )
@@ -76,12 +73,8 @@ export class Track {
       try {
         const ytInfo = await exec(url, {
           dumpSingleJson: true,
-          noWarnings: true,
           preferFreeFormats: true,
-          extractorArgs: 'youtube:player_client=android,ios,web',
-          addHeader: [
-            'User-Agent:Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-          ],
+          ...ytdlpCommonOptions(),
         }, { stdio: ['ignore', 'pipe', 'pipe'] })
 
         const data = JSON.parse(ytInfo.stdout.toString())

--- a/src/handlers/music/ytdlp-options.ts
+++ b/src/handlers/music/ytdlp-options.ts
@@ -1,0 +1,91 @@
+import { writeFileSync, mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createLogger } from '../../shared/logger/Logger'
+
+const log = createLogger('ytdlp-options')
+
+/**
+ * User-Agent de um Chrome desktop recente. Mantido fixo para que o client
+ * `web`/`web_safari` do yt-dlp pareça um navegador real.
+ */
+const USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+
+/**
+ * Lista de player clients usada na extração.
+ *
+ * IMPORTANTE: os clients `android`/`ios` passaram a exigir PO token e, em IPs
+ * de datacenter (Heroku/VPS), disparam o muro "Sign in to confirm you're not a
+ * bot". Os clients `tv` e `web_safari` são os mais resilientes hoje sem PO
+ * token. Quando há cookies de uma conta logada, o `web` volta a funcionar.
+ *
+ * Pode ser sobrescrito via `YTDLP_PLAYER_CLIENT` (ex.: "default", "tv,web").
+ */
+const DEFAULT_PLAYER_CLIENT = 'tv,web_safari'
+
+let cachedCookiesFile: string | null | undefined
+
+/**
+ * Resolve, uma única vez, o caminho do arquivo de cookies a partir das envs:
+ *
+ *  - `YOUTUBE_COOKIES_FILE`: caminho de um cookies.txt já existente no disco.
+ *  - `YOUTUBE_COOKIES_B64`:  conteúdo do cookies.txt codificado em base64
+ *                           (prático para Heroku/config vars). É escrito em um
+ *                           arquivo temporário no boot.
+ *
+ * Retorna `null` quando nenhuma das duas está definida (extração sem cookies).
+ */
+function resolveCookiesFile(): string | null {
+  if (cachedCookiesFile !== undefined) return cachedCookiesFile
+
+  const explicitPath = process.env.YOUTUBE_COOKIES_FILE?.trim()
+  if (explicitPath) {
+    log.info({ path: explicitPath }, 'Usando cookies do YouTube via YOUTUBE_COOKIES_FILE')
+    cachedCookiesFile = explicitPath
+    return cachedCookiesFile
+  }
+
+  const b64 = process.env.YOUTUBE_COOKIES_B64?.trim()
+  if (b64) {
+    try {
+      const content = Buffer.from(b64, 'base64').toString('utf8')
+      const dir = mkdtempSync(join(tmpdir(), 'ytdlp-cookies-'))
+      const file = join(dir, 'cookies.txt')
+      writeFileSync(file, content, { mode: 0o600 })
+      log.info({ path: file }, 'Cookies do YouTube materializados a partir de YOUTUBE_COOKIES_B64')
+      cachedCookiesFile = file
+      return cachedCookiesFile
+    } catch (err) {
+      log.error({ err }, 'Falha ao decodificar YOUTUBE_COOKIES_B64 — seguindo sem cookies')
+    }
+  }
+
+  cachedCookiesFile = null
+  return cachedCookiesFile
+}
+
+/**
+ * Opções comuns do yt-dlp compartilhadas entre `Track.from` (metadados) e
+ * `Track.createAudioResource` (stream de áudio). Inclui cookies quando
+ * configurados — a forma confiável de driblar o anti-bot em IP de datacenter.
+ */
+export function ytdlpCommonOptions(): Record<string, unknown> {
+  const playerClient = process.env.YTDLP_PLAYER_CLIENT?.trim() || DEFAULT_PLAYER_CLIENT
+
+  const options: Record<string, unknown> = {
+    noWarnings: true,
+    extractorArgs: `youtube:player_client=${playerClient}`,
+    addHeader: [`User-Agent:${USER_AGENT}`],
+  }
+
+  const cookiesFile = resolveCookiesFile()
+  if (cookiesFile) options.cookies = cookiesFile
+
+  return options
+}
+
+/** Indica se há cookies configurados (para diagnóstico/log). */
+export function hasCookiesConfigured(): boolean {
+  return resolveCookiesFile() !== null
+}


### PR DESCRIPTION
## Problema

O player de música caía há tempos no erro do yt-dlp:

```
ERROR: [youtube] <id>: Sign in to confirm you're not a bot.
Use --cookies-from-browser or --cookies for the authentication.
```

É o **muro anti-bot do YouTube** contra IPs de datacenter (Heroku, `app[worker.1]` nos logs) — diferente do HTTP 403 já documentado. A config antiga `player_client=android,ios,web` virou parte do problema: `android`/`ios` passaram a exigir **PO token** e o `web` sem cookies num IP flagrado cai direto no muro.

## Mudanças

- **Novo `src/handlers/music/ytdlp-options.ts`** com as opções comuns de extração:
  - **Cookies** via `YOUTUBE_COOKIES_B64` (base64 do `cookies.txt`) ou `YOUTUBE_COOKIES_FILE` (caminho) — materializados em arquivo temporário no boot e passados como `--cookies`. É a forma confiável de driblar o anti-bot em IP de datacenter.
  - **player_client** default `tv,web_safari` (mais resilientes sem PO token), sobrescrevível por `YTDLP_PLAYER_CLIENT`.
- **`track.ts`**: `Track.from` (metadados) e `createAudioResource` (stream) agora usam o helper — fim da duplicação e do client problemático.
- **`Dockerfile`**: baixa a release mais recente do `yt-dlp` por cima do binário empacotado pelo `youtube-dl-exec` (que costuma vir velho). Python mantido como dependência de runtime.
- **`env.ts`**: valida as novas variáveis; **`.env.example`** e **`docs/TROUBLESHOOTING_MUSICA_VOZ.md`** (nova seção B.5) atualizados.

## Como ativar (passo manual necessário)

O fix de código sozinho ajuda, mas em IP de datacenter a parte confiável são os **cookies**:

1. No navegador logado no YouTube (de preferência conta descartável), exporte `cookies.txt` (formato Netscape — extensão "Get cookies.txt").
2. `base64 -w0 cookies.txt`
3. `heroku config:set YOUTUBE_COOKIES_B64=<resultado>`

Cookies expiram; se o muro voltar, gere um `cookies.txt` novo.

## Testes

- `npm run build` limpo nos arquivos alterados.
- `npx jest`: **99 testes passando** (15 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyYpMZuRtHTm4omWyvpuA8)_